### PR TITLE
Fix hang reconnecting after returning to backgrounded app

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,6 +41,15 @@ blocks the current build, which is green.
       A design decision from 2010. Under modern background restrictions the process can be reclaimed
       and the connection dies with it. This is the most likely cause of "the app just stops
       responding" reports.
+- [ ] Two races in the resume path, flagged in PR #13 review, not fixed there because both predate
+      that PR and are independent of its Doze-detection change:
+      `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()` →
+      `threadHandler.join()` (`core/ResilentConnector.java:241`, unbounded — see also the `join(1000)`
+      at `:47`) runs on the UI thread, so a slow `checkAddress()`/`connect()` in the old thread can
+      block resume long enough to ANR. Separately, `java.util.Timer` catches up on missed ticks once
+      the process thaws, so a `StopConnectorTask` deferred by Doze (`ActiveHandler.java`'s
+      `StopConnectorTask.run()`) can fire just after resume and stop a connection
+      `contextResumed()` just rebuilt; `cancelCurrentTask()` only helps if it wins that race.
 
 ## Time bomb, no fuse length known
 

--- a/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
+++ b/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
@@ -41,9 +41,21 @@ public final class ActiveHandler {
 	public void contextResumed(Context context) {
 		Logger.info("ActiveHandler.activity resumed " + context);
 		activeContext = context;
+		// Solange der geplante "StopConnectorTask" noch nicht gefeuert hat,
+		// war die Pause kurz (< disconnectTimeout) -> die Verbindung gilt
+		// noch als frisch und vertrauenswuerdig.
+		final boolean quickReturn = task != null;
 		cancelCurrentTask();
-		if (!connector.isRunning()) {
-			connector.reconfigure(context);
+		if (quickReturn) {
+			if (!connector.isRunning()) {
+				connector.reconfigure(context);
+			}
+		} else {
+			// Laenger im Hintergrund (oder der Task konnte durch Doze/App-
+			// Standby verzoegert werden) -> "isRunning()" beruht evtl. auf
+			// einem Socket, den Android stillschweigend gekappt hat. Statt
+			// dem zu vertrauen, Verbindung immer frisch aufbauen.
+			connector.forceReconnect();
 		}
 	}
 

--- a/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
+++ b/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
@@ -20,6 +20,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import android.content.Context;
+import android.os.SystemClock;
 import de.pskiwi.avrremote.core.ResilentConnector;
 import de.pskiwi.avrremote.log.Logger;
 
@@ -41,10 +42,15 @@ public final class ActiveHandler {
 	public void contextResumed(Context context) {
 		Logger.info("ActiveHandler.activity resumed " + context);
 		activeContext = context;
-		// Solange der geplante "StopConnectorTask" noch nicht gefeuert hat,
-		// war die Pause kurz (< disconnectTimeout) -> die Verbindung gilt
-		// noch als frisch und vertrauenswuerdig.
-		final boolean quickReturn = task != null;
+		// "task != null" allein reicht nicht: der Timer kann durch Doze/App-
+		// Standby beliebig verzoegert werden, auch weit ueber disconnectTimeout
+		// hinaus, ohne dass StopConnectorTask je gefeuert hat. Stattdessen die
+		// tatsaechlich vergangene Zeit seit contextPaused() gegen den Timeout
+		// pruefen.
+		final boolean quickReturn = pausedAtElapsedRealtime >= 0
+				&& SystemClock.elapsedRealtime() - pausedAtElapsedRealtime < AVRSettings
+						.getDisconnectTimeout(context) * 1000L;
+		pausedAtElapsedRealtime = -1;
 		cancelCurrentTask();
 		if (quickReturn) {
 			if (!connector.isRunning()) {
@@ -70,6 +76,7 @@ public final class ActiveHandler {
 			final int disconnectTimeout = AVRSettings
 					.getDisconnectTimeout(context);
 			Logger.debug("auto disconnect :" + disconnectTimeout + "sec");
+			pausedAtElapsedRealtime = SystemClock.elapsedRealtime();
 			timer.schedule(task, disconnectTimeout * 1000);
 			activeContext = null;
 		}
@@ -94,6 +101,8 @@ public final class ActiveHandler {
 
 	// Die Variable task darf nur im EDT verändert werden !
 	private TimerTask task;
+	// -1 = kein Pause-Zeitpunkt gemerkt (z.B. allererstes contextResumed())
+	private long pausedAtElapsedRealtime = -1;
 	private Context activeContext;
 	private final Timer timer = new Timer("StopConnector-Timer", true);
 	private final ResilentConnector connector;

--- a/app/src/main/java/de/pskiwi/avrremote/core/ResilentConnector.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/ResilentConnector.java
@@ -19,6 +19,7 @@ package de.pskiwi.avrremote.core;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import android.content.Context;
 import de.pskiwi.avrremote.EnableManager;
@@ -64,10 +65,25 @@ public final class ResilentConnector implements ISender {
 
 	private class Reconnector implements Runnable {
 
+		Reconnector(int epoch) {
+			this.epoch = epoch;
+		}
+
+		// Ein Thread, der z.B. in einem blockierenden Connect/Ping haengt,
+		// reagiert nicht auf interrupt(). Damit so ein "Zombie"-Thread nach
+		// einem stop()/reconfigure() nicht spaeter doch noch den geteilten
+		// "connector" Status ueberschreibt, darf er nur publizieren, solange
+		// seine Generation noch aktuell ist.
+		private boolean isCurrent() {
+			return generation.get() == epoch;
+		}
+
 		public void run() {
-			while (!Thread.currentThread().isInterrupted()) {
+			while (!Thread.currentThread().isInterrupted() && isCurrent()) {
 				try {
-					connector = IConnector.NULL_CONNECTOR;
+					if (isCurrent()) {
+						connector = IConnector.NULL_CONNECTOR;
+					}
 					Logger.info("Reconnector:build new connection to ["
 							+ connectionConfig + "]");
 					boolean reachable = connectionConfig.checkAddress(false);
@@ -76,11 +92,16 @@ public final class ResilentConnector implements ISender {
 					// reachable nicht direkt in Status setzen, um mehrfache
 					// Updates zu vermeiden
 
+					if (!isCurrent()) {
+						return;
+					}
+
 					// Auf jeden Fall versuchen, u.U. ist der Test auf manchen
 					// Modellen nicht eindeutig.
+					IConnector newConnector;
 					try {
-						connector = new Connector(connectionConfig, SEND_DELAY,
-								eventListener);
+						newConnector = new Connector(connectionConfig,
+								SEND_DELAY, eventListener);
 					} catch (Throwable x) {
 						// Bei Fehler Reachable setzen, sonst wird Reachable
 						// über "Connected" mit gesetzt
@@ -88,6 +109,17 @@ public final class ResilentConnector implements ISender {
 								.setStatus(StatusFlag.Reachable, reachable);
 						throw x;
 					}
+
+					if (!isCurrent()) {
+						// wurde waehrend des (nicht unterbrechbaren) Connects
+						// bereits gestoppt/neu gestartet -> verwerfen
+						Logger.info("Reconnector:superseded while connecting -> discard ["
+								+ connectionConfig + "]");
+						newConnector.close();
+						return;
+					}
+
+					connector = newConnector;
 					reconnectDelayIndex = 0;
 					Logger.info("Reconnector:connection to ["
 							+ connectionConfig + "] established");
@@ -95,6 +127,11 @@ public final class ResilentConnector implements ISender {
 					connector.waitUntilClosed();
 					Logger.info("Reconnector:Reconnector:connection to ["
 							+ connectionConfig + "] closed");
+
+					if (!isCurrent()) {
+						return;
+					}
+
 					// Reachable-Status direkt aktualisieren, nicht erst 15sec
 					// warten (schnelleres Feedback)
 					reachable = connectionConfig.checkAddress(true);
@@ -112,9 +149,14 @@ public final class ResilentConnector implements ISender {
 				} catch (IOException x) {
 					Logger.error("Reconnector:IOException [" + connectionConfig
 							+ "]", x);
-					enableManager.setStatus(StatusFlag.Connected, false);
+					if (isCurrent()) {
+						enableManager.setStatus(StatusFlag.Connected, false);
+					}
 				} catch (Throwable x) {
 					Logger.error("Reconnector:connection failed", x);
+				}
+				if (!isCurrent()) {
+					return;
 				}
 				try {
 					if (reconnectDelayIndex < RECONNECT_DELAY.length - 1) {
@@ -132,6 +174,7 @@ public final class ResilentConnector implements ISender {
 		}
 
 		private int reconnectDelayIndex = 0;
+		private final int epoch;
 
 	}
 
@@ -159,16 +202,41 @@ public final class ResilentConnector implements ISender {
 
 	}
 
+	/**
+	 * Wie {@link #reconfigure(Context)}, aber ohne die "laeuft schon /
+	 * Config unveraendert" Kurzschluss-Pruefung. Wird beim Resume einer
+	 * Activity benutzt: dort ist "isRunning()" nicht vertrauenswuerdig, da
+	 * Android den Socket/Timer waehrend des Hintergrundbetriebs (Doze,
+	 * Netzwechsel) einfrieren oder stillschweigend kappen kann, ohne dass
+	 * unser Code das mitbekommt.
+	 */
+	public void forceReconnect() {
+		final ConnectionConfiguration newConfig = modelConfigurator
+				.getConnectionConfig();
+		Logger.info("Connector forceReconnect ip: [" + newConfig + "]");
+		clearState();
+		connectionConfig = newConfig;
+		stopConnector();
+		if (newConfig.isDefined()) {
+			startConnector();
+		}
+	}
+
 	private void startConnector() {
 		Logger.info("Reconnector:start new connector " + connectionConfig);
 		if (connectionConfig.isDefined()) {
-			threadHandler.start(new Reconnector());
+			threadHandler.start(new Reconnector(generation.incrementAndGet()));
 		} else {
 			Logger.info("startConnector ignored: " + connectionConfig);
 		}
 	}
 
 	private void stopConnector() {
+		// invalidiert einen evtl. noch laufenden "Zombie"-Thread (z.B. in
+		// einem nicht unterbrechbaren Connect/Ping haengend), so dass dieser
+		// keine Werte mehr publizieren darf, selbst wenn threadHandler.join()
+		// unten in den Timeout laeuft.
+		generation.incrementAndGet();
 		try {
 			threadHandler.join();
 		} finally {
@@ -273,6 +341,7 @@ public final class ResilentConnector implements ISender {
 	private volatile IConnector connector = IConnector.NULL_CONNECTOR;
 	private ConnectionConfiguration connectionConfig = ConnectionConfiguration.UNDEFINED;
 	private final ThreadHandler threadHandler = new ThreadHandler();
+	private final AtomicInteger generation = new AtomicInteger();
 	private static int[] RECONNECT_DELAY = { 1, 2, 4, 8, 16 };
 	// totale Wartezeit für einen Connect-Test
 	public final static int RECONNECT_WAIT_TIME;


### PR DESCRIPTION
isRunning() trusted Socket.isConnected(), which Android never clears even when the OS silently drops the connection while the process is frozen in the background (Doze/App Standby). On resume the app could believe it was still connected to a dead socket and never attempt a new connection.

Also guard against a stale Reconnector thread: checkAddress()/connect() block for several seconds without responding to interrupt(), so ThreadHandler.join()'s 1s wait could give up while the old thread was still alive, letting it later overwrite the live connector or leak an open socket. A generation counter now makes superseded threads discard their result and close their socket instead of publishing it.