### PR TITLE
Update to Android SDK 36 (AGP 8.13, Gradle 8.13, JDK 17)

### DIFF
--- a/.github/workflows/checkbuild.yml
+++ b/.github/workflows/checkbuild.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - uses: gradle/actions/wrapper-validation@v6
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 app/build
 build
 .idea
+local.properties

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Android remote control for Denon and Marantz AV receivers (`de.pskiwi.avrremote`, GPL v3).
+Talks to receivers on the local network — there is no backend and no account.
+
+## Build and run
+
+The README still says JDK 8; that is outdated. The build needs **JDK 17** and **Android SDK 36**:
+
+```sh
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17          # keg-only formula, not on PATH by default
+export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
+
+./gradlew assembleDebug     # APK -> app/build/outputs/apk/debug/app-debug.apk
+./gradlew build             # what CI runs: assemble + lint, both variants
+$ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+`local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
+
+**There are no tests.** No `src/test`, no `src/androidTest`, no test dependencies. `./gradlew test`
+succeeds but runs nothing. Do not report a change as verified because the build passed; verify on a
+device or emulator instead. Lint runs with `abortOnError false`, so lint *errors* do not fail the
+build — check `app/build/reports/lint-results-debug.html` explicitly when it matters.
+
+Release builds are signed only when `~/keystore.properties` exists or the `KEY_ALIAS` /
+`KEY_PASSWORD` / `STORE_FILE` / `STORE_PASSWORD` env vars are set; otherwise
+`app-release-unsigned.apk` is produced and cannot be installed.
+
+## Architecture
+
+### Two independent transports
+
+1. **Telnet, port 23** — the real control channel. `core/Connector` holds a raw socket, writes
+   commands terminated with `\r`, and parses incoming lines into `InData`.
+2. **HTTP** — `http/AVRHTTPClient` scrapes the receiver's own web UI (`*.asp`, XML endpoints) for
+   things the telnet protocol does not expose: input/zone names, quick-select presets, NET audio
+   search. `http/Series08*` parse the 2008-series variant. This is the only Apache-HTTP code left
+   (`useLibrary 'org.apache.http.legacy'`).
+
+### State flow
+
+```
+ResilentConnector (daemon thread, reconnect loop)  ->  Connector (socket)
+        -> AVRState.received(InData)  ->  ZoneState[zone]  ->  listeners
+        -> IGUIExecutor (Handler.post) ->  main thread
+```
+
+`ResilentConnector` runs a long-lived reconnect loop on a plain daemon thread owned by
+`AVRApplication` — **not** a Service. Killing or backgrounding the app kills the connection.
+
+`AVRApplication` is the central object graph: `getAvrState()`, `getConnector()`, `getEnableManager()`,
+`getModelConfigurator()`, `getDisplayManager()`, `getRenameService()`, `getMacroManager()` and more.
+Activities reach everything through `(AVRApplication) getApplication()`.
+
+`EnableManager` drives view enablement from a small set of `StatusFlag`s (`WLAN`, `Reachable`,
+`Connected`, `Power`, `Zone1`–`Zone4`). This is why most buttons are greyed out until a receiver is
+actually connected — worth knowing when testing without hardware.
+
+`IStateFilter` decides which screen currently receives state updates, so background activities do not
+fight over the display listener.
+
+`core/display/` parses the receiver's on-screen display into `DisplayLine`s. `NetDisplay`,
+`TunerDisplay` and `BDDisplay` are three separate, large parsers for different input types.
+
+Up to 4 zones and up to 3 receivers are supported; the receiver index threads through
+`AVRSettings.getAVRModel(ctx, receiverNr)` and the `receiverSuffix()` preference-key convention.
+
+### Receiver models — reflection registry
+
+`models/` holds 67 classes, one per receiver family, all extending `AbstractModel` and overriding
+capability predicates (`hasZones()`, `hasQuick()`, `getSupportedLevels()`, `supportsDAB()`, …).
+
+`ModelConfigurator.update()` resolves the model **by reflection** from the user's preference string:
+
+```
+"AVR-3310"  --strip "-"--> "AVR3310"  -->  Class.forName("de.pskiwi.avrremote.models.AVR3310")
+```
+
+A trailing `(experimental)` is stripped too, and any failure silently falls back to `AVRGeneric`.
+
+Consequences:
+- Adding a receiver needs **two** changes: a class in `models/` *and* an entry in
+  `@array/modelNames` in `res/values/lists.xml`. The names must correspond after dash-stripping.
+- The model classes have no static references. Never enable R8/ProGuard shrinking without a
+  keep rule for `de.pskiwi.avrremote.models.**`.
+
+## Conventions and constraints
+
+- **No AndroidX, no third-party dependencies.** `app/build.gradle` has no `dependencies {}` block at
+  all. Everything is raw framework API. Keep it that way unless explicitly asked — adding AndroidX
+  would pull the whole legacy UI stack into a migration.
+- The UI is built on deprecated bases: `TabActivity`, `ListActivity`, `ExpandableListActivity`,
+  `PreferenceActivity`, `TabHost`/`TabWidget` layouts, and pre-Holo `Theme.NoTitleBar` themes.
+  They still compile; match the surrounding style rather than modernising piecemeal.
+- Indentation is tabs. Comments are a mix of German and English.
+- `android.nonFinalResIds=false` in `gradle.properties` is load-bearing: it keeps `R` fields final so
+  the `switch`/`case R.id.*` in `menu/OptionsMenu.java` compiles. Do not remove it without rewriting
+  that file to `if`/`else`.
+
+### When adding an Activity
+
+Two things are easy to forget and both are required at `targetSdk 36`:
+
+1. `android:exported="false"` in the manifest — missing it is a **build error**, not a warning.
+2. `EdgeToEdge.apply(this)` right after `setContentView(...)`. Edge-to-edge is enforced with no
+   opt-out; without it the content draws under the status and navigation bars, because none of the
+   themes have an ActionBar to absorb the insets. Dialog-themed activities (`OptionActivity`) do not
+   need it.
+
+## Known-broken, pre-existing
+
+Do not treat these as regressions; they predate the SDK 36 upgrade:
+
+- `log/SDLogger` writes to `Environment.getExternalStorageDirectory()` — fails under scoped storage
+  since Android 10. `WRITE_EXTERNAL_STORAGE` in the manifest has been a no-op since Android 11.
+- `SDLogger.getLogURI()` returns a `file://` URI that `log/FeedbackReporter` puts into
+  `Intent.EXTRA_STREAM` — throws `FileUriExposedException`. Sending logs needs a `FileProvider`.
+- The custom-background picker (`AVRSettings`) stores the URI without
+  `takePersistableUriPermission()`, so it does not survive a restart.
+
+## Next SDK step
+
+Local Network Protection becomes mandatory for apps targeting **Android 17 (SDK 37)**. That directly
+hits `scan/AVRScanner` (subnet sweep) and the raw receiver sockets — i.e. the core of the app. At
+`targetSdk 36` it does not apply yet, but plan for a runtime local-network permission before raising
+the target further.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Talks to receivers on the local network — there is no backend and no account.
 
 ## Build and run
 
-The README still says JDK 8; that is outdated. The build needs **JDK 17** and **Android SDK 36**:
+The build needs **JDK 17** and **Android SDK Platform 36**:
 
 ```sh
 export JAVA_HOME=/opt/homebrew/opt/openjdk@17          # keg-only formula, not on PATH by default
@@ -95,7 +95,8 @@ Consequences:
   all. Everything is raw framework API. Keep it that way unless explicitly asked — adding AndroidX
   would pull the whole legacy UI stack into a migration.
 - The UI is built on deprecated bases: `TabActivity`, `ListActivity`, `ExpandableListActivity`,
-  `PreferenceActivity`, `TabHost`/`TabWidget` layouts, and pre-Holo `Theme.NoTitleBar` themes.
+  `PreferenceActivity`, `TabHost`/`TabWidget` layouts, and pre-Holo platform themes
+  (`Theme.NoTitleBar`, plus `Theme.Light` and `Theme.Dialog` used directly from the manifest).
   They still compile; match the surrounding style rather than modernising piecemeal.
 - Indentation is tabs. Comments are a mix of German and English.
 - `android.nonFinalResIds=false` in `gradle.properties` is load-bearing: it keeps `R` fields final so
@@ -106,11 +107,14 @@ Consequences:
 
 Two things are easy to forget and both are required at `targetSdk 36`:
 
-1. `android:exported="false"` in the manifest — missing it is a **build error**, not a warning.
+1. `android:exported` in the manifest. For a component **with** an intent filter, omitting it is a
+   build error; without a filter it is optional but set explicitly here for consistency.
 2. `EdgeToEdge.apply(this)` right after `setContentView(...)`. Edge-to-edge is enforced with no
    opt-out; without it the content draws under the status and navigation bars, because none of the
    themes have an ActionBar to absorb the insets. Dialog-themed activities (`OptionActivity`) do not
    need it.
+3. If the activity requests a runtime permission, gate the request on
+   `savedInstanceState == null` — these activities are recreated on every rotation.
 
 ## Known-broken, pre-existing
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,32 @@ Android remote control for Denon and Marantz receivers.
 This application is not affiliated with Denon or Marantz. 
 Denon and Marantz are registered trademarks of D&M Holdings, Inc. 
 
-![Java CI with Gradle](https://github.com/pskiwi/avr-remote/workflows/Java%20CI%20with%20Gradle/badge.svg)
+![Check build](https://github.com/pskiwi/avr-remote/workflows/Check%20build/badge.svg)
+
+Runs on Android 7.0 (API 24) and newer.
 
 ## Required Tools
 
-* JDK 8
-* Android Studio
+* JDK 17
+* Android SDK Platform 36
+* Android Studio (optional, the Gradle wrapper is enough)
 
 ## Build
 
-`./gradlew build`
+```sh
+export JAVA_HOME=/path/to/jdk-17
+export ANDROID_HOME=/path/to/android-sdk
+
+./gradlew build
+```
+
+The debug APK is written to `app/build/outputs/apk/debug/app-debug.apk`.
+
+`local.properties` is not checked in; the SDK location is taken from `ANDROID_HOME`.
+
+Release builds are signed only if `~/keystore.properties` exists or the `KEY_ALIAS`,
+`KEY_PASSWORD`, `STORE_FILE` and `STORE_PASSWORD` environment variables are set.
+Without those, `./gradlew build` produces an unsigned release APK.
 
 ## Receiver specs
 Search for

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,17 +9,22 @@ if (keystorePropertiesFile.canRead()) {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    namespace "de.pskiwi.avrremote"
+    compileSdk 36
+    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "de.pskiwi.avrremote"
-        minSdkVersion 8
-        targetSdkVersion 30
-        useLibrary 'org.apache.http.legacy'
+        minSdk 24
+        targetSdk 36
     }
 
-    lintOptions {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    lint {
         abortOnError false
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="de.pskiwi.avrremote"
     android:installLocation="auto"
     android:label="AVR-Remote"
     android:versionCode="124"
@@ -20,7 +19,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" >
     </uses-permission>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" >
-    </uses-permission>  
+    </uses-permission>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="AVRApplication"
@@ -32,6 +32,7 @@
         >
         <activity
             android:name=".AVRRemote"
+            android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/AVRActivity" >
             <intent-filter>
@@ -42,24 +43,30 @@
         </activity>
         <activity
             android:name=".AVRSettings"
+            android:exported="false"
             android:label="Settings" />
         <activity
             android:name=".LevelActivity"
+            android:exported="false"
             android:label="Level"
             android:theme="@android:style/Theme.Light" />
         <activity
             android:name=".OnScreenDisplayActivity"
+            android:exported="false"
             android:label="OSD"
             android:theme="@style/AVRActivity" />
         <activity
             android:name=".RenameActivity"
+            android:exported="false"
             android:label="Rename"
             android:theme="@style/AVRActivity" />
         <activity
             android:name=".AboutActivity"
+            android:exported="false"
             android:label="@string/about_title" />
         <activity
             android:name=".OptionActivity"
+            android:exported="false"
             android:label="Options"
             android:theme="@android:style/Theme.Dialog" />
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>

--- a/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
@@ -93,6 +93,7 @@ public final class AVRApplication extends Application {
 
 	@Override
 	public void onCreate() {
+		super.onCreate();
 
 		Logger.setDelegate(ADBLogger.INSTANCE);
 

--- a/app/src/main/java/de/pskiwi/avrremote/AVRRemote.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRRemote.java
@@ -22,7 +22,9 @@ import android.app.Activity;
 import android.app.TabActivity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Display;
 import android.view.KeyEvent;
@@ -103,6 +105,8 @@ public final class AVRRemote extends TabActivity implements IActivityShowing,
 
 		Logger.info("start AVR-Remote " + FeedbackReporter.getVersionInfo(this));
 		setContentView(R.layout.tabhost);
+		EdgeToEdge.apply(this);
+		requestNotificationPermission();
 
 		Logger.setLocation("AVRRemote-onCreate-2");
 
@@ -206,6 +210,35 @@ public final class AVRRemote extends TabActivity implements IActivityShowing,
 		}
 		Logger.info("init Timer.");
 		Logger.info("AVRRemote:init ok.");
+	}
+
+	/**
+	 * Ab targetSdk 33 wird die Dauerbenachrichtigung ohne diese Runtime-Permission
+	 * kommentarlos verworfen.
+	 */
+	private void requestNotificationPermission() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+			return;
+		}
+		if (!AVRSettings.isShowNotification(this)) {
+			return;
+		}
+		if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+			requestPermissions(
+					new String[] { android.Manifest.permission.POST_NOTIFICATIONS },
+					REQUEST_POST_NOTIFICATIONS);
+		}
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, String[] permissions,
+			int[] grantResults) {
+		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+		if (requestCode == REQUEST_POST_NOTIFICATIONS && grantResults.length > 0
+				&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+			// Benachrichtigung nachziehen, die beim Start noch verworfen wurde
+			getApp().getStatusbarManager().update();
+		}
 	}
 
 	private ZoneState getCurrentFrontState() {
@@ -575,5 +608,6 @@ public final class AVRRemote extends TabActivity implements IActivityShowing,
 	// Achtung, kann "null" sein
 	private ZoneState currentZoneState;
 	private static final String CURRENT_TAB = "CURRENT_TAB";
+	private static final int REQUEST_POST_NOTIFICATIONS = 1;
 
 }

--- a/app/src/main/java/de/pskiwi/avrremote/AVRRemote.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRRemote.java
@@ -24,7 +24,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Display;
 import android.view.KeyEvent;
@@ -106,7 +105,10 @@ public final class AVRRemote extends TabActivity implements IActivityShowing,
 		Logger.info("start AVR-Remote " + FeedbackReporter.getVersionInfo(this));
 		setContentView(R.layout.tabhost);
 		EdgeToEdge.apply(this);
-		requestNotificationPermission();
+		if (savedInstanceState == null) {
+			// nicht bei jeder Drehung erneut anfragen
+			AVRSettings.requestNotificationPermission(this);
+		}
 
 		Logger.setLocation("AVRRemote-onCreate-2");
 
@@ -212,29 +214,12 @@ public final class AVRRemote extends TabActivity implements IActivityShowing,
 		Logger.info("AVRRemote:init ok.");
 	}
 
-	/**
-	 * Ab targetSdk 33 wird die Dauerbenachrichtigung ohne diese Runtime-Permission
-	 * kommentarlos verworfen.
-	 */
-	private void requestNotificationPermission() {
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-			return;
-		}
-		if (!AVRSettings.isShowNotification(this)) {
-			return;
-		}
-		if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-			requestPermissions(
-					new String[] { android.Manifest.permission.POST_NOTIFICATIONS },
-					REQUEST_POST_NOTIFICATIONS);
-		}
-	}
-
 	@Override
 	public void onRequestPermissionsResult(int requestCode, String[] permissions,
 			int[] grantResults) {
 		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-		if (requestCode == REQUEST_POST_NOTIFICATIONS && grantResults.length > 0
+		if (requestCode == AVRSettings.REQUEST_POST_NOTIFICATIONS
+				&& grantResults.length > 0
 				&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
 			// Benachrichtigung nachziehen, die beim Start noch verworfen wurde
 			getApp().getStatusbarManager().update();
@@ -608,6 +593,5 @@ public final class AVRRemote extends TabActivity implements IActivityShowing,
 	// Achtung, kann "null" sein
 	private ZoneState currentZoneState;
 	private static final String CURRENT_TAB = "CURRENT_TAB";
-	private static final int REQUEST_POST_NOTIFICATIONS = 1;
 
 }

--- a/app/src/main/java/de/pskiwi/avrremote/AVRSettings.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRSettings.java
@@ -46,6 +46,7 @@ public final class AVRSettings extends PreferenceActivity implements
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.settings);
+		EdgeToEdge.apply(this);
 
 		getPreferenceScreen().getSharedPreferences()
 				.registerOnSharedPreferenceChangeListener(this);

--- a/app/src/main/java/de/pskiwi/avrremote/AVRSettings.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRSettings.java
@@ -27,9 +27,11 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
@@ -97,6 +99,31 @@ public final class AVRSettings extends PreferenceActivity implements
 		summaryUpdater.updateSummaryForKey(key);
 		checkIPSetting();
 		getApp().getAvrTheme().update();
+		if (NOTIFICATION_KEY.equals(key)) {
+			// Der Nutzer hat die Benachrichtigung gerade eingeschaltet - die
+			// Permission genau hier anfragen. Beim Verlassen der Settings postet
+			// reconfigure() die Benachrichtigung, das braucht sie bis dahin.
+			requestNotificationPermission(this);
+		}
+	}
+
+	/**
+	 * Fragt POST_NOTIFICATIONS an, wenn die Benachrichtigung aktiviert ist und
+	 * die Permission noch fehlt. Ohne sie verwirft Android ab targetSdk 33 die
+	 * Benachrichtigung kommentarlos.
+	 */
+	public static void requestNotificationPermission(Activity activity) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+			return;
+		}
+		if (!isShowNotification(activity)) {
+			return;
+		}
+		if (activity.checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+			activity.requestPermissions(
+					new String[] { android.Manifest.permission.POST_NOTIFICATIONS },
+					REQUEST_POST_NOTIFICATIONS);
+		}
 	}
 
 	@Override
@@ -283,7 +310,7 @@ public final class AVRSettings extends PreferenceActivity implements
 
 	public static boolean isShowNotification(Context ctx) {
 		return PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean(
-				"AVRNotification", false);
+				NOTIFICATION_KEY, false);
 	}
 
 	public static int getAVRIndex(Context ctx) {
@@ -416,7 +443,9 @@ public final class AVRSettings extends PreferenceActivity implements
 	private static final String LEVEL_PRESET = "LevelPreset";
 	private final static String AVRIP = "avrip";
 	private final static String AVRMACRO = "avrmacro_";
+	private final static String NOTIFICATION_KEY = "AVRNotification";
 	protected static final int SELECT_IMAGE = 6789;
+	public static final int REQUEST_POST_NOTIFICATIONS = 1;
 	
 	public static final int MAX_RECEIVERS = 3;
 

--- a/app/src/main/java/de/pskiwi/avrremote/AboutActivity.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AboutActivity.java
@@ -33,6 +33,7 @@ public final class AboutActivity extends TabActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.infotabhost);
+		EdgeToEdge.apply(this);
 
 		initTab(R.id.panel_about, R.id.info_about, "about",
 				getString(R.string.About));

--- a/app/src/main/java/de/pskiwi/avrremote/EdgeToEdge.java
+++ b/app/src/main/java/de/pskiwi/avrremote/EdgeToEdge.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote;
+
+import android.app.Activity;
+import android.graphics.Insets;
+import android.os.Build;
+import android.view.View;
+import android.view.WindowInsets;
+
+/**
+ * Ab targetSdk 36 erzwingt Android edge-to-edge ohne Opt-Out. Da alle Themes
+ * dieser App von Theme.NoTitleBar erben, gibt es keine ActionBar, welche die
+ * System-Leisten abfangen würde - der Inhalt würde darunter zeichnen.
+ */
+public final class EdgeToEdge {
+
+	/**
+	 * Legt System-Leisten, Display-Cutout und Tastatur als Padding auf den
+	 * Content-View, damit der Inhalt nicht darunter zeichnet.
+	 */
+	public static void apply(Activity activity) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+			return;
+		}
+		final View content = activity.findViewById(android.R.id.content);
+		content.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+			public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+				// ime() mit einbeziehen, damit Eingabefelder nicht von der
+				// Tastatur verdeckt werden.
+				Insets bars = insets.getInsets(WindowInsets.Type.systemBars()
+						| WindowInsets.Type.displayCutout()
+						| WindowInsets.Type.ime());
+				v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+				return WindowInsets.CONSUMED;
+			}
+		});
+		content.requestApplyInsets();
+	}
+
+	private EdgeToEdge() {
+	}
+
+}

--- a/app/src/main/java/de/pskiwi/avrremote/EdgeToEdge.java
+++ b/app/src/main/java/de/pskiwi/avrremote/EdgeToEdge.java
@@ -23,28 +23,29 @@ import android.view.View;
 import android.view.WindowInsets;
 
 /**
- * Ab targetSdk 36 erzwingt Android edge-to-edge ohne Opt-Out. Da alle Themes
- * dieser App von Theme.NoTitleBar erben, gibt es keine ActionBar, welche die
- * System-Leisten abfangen würde - der Inhalt würde darunter zeichnen.
+ * Ab targetSdk 36 erzwingt Android edge-to-edge ohne Opt-Out. Keines der hier
+ * verwendeten Themes hat eine ActionBar, welche die System-Leisten abfangen
+ * würde - der Inhalt würde sonst darunter zeichnen.
  */
 public final class EdgeToEdge {
 
 	/**
-	 * Legt System-Leisten, Display-Cutout und Tastatur als Padding auf den
-	 * Content-View, damit der Inhalt nicht darunter zeichnet.
+	 * Legt System-Leisten und Display-Cutout als Padding auf den Content-View.
+	 * Nach setContentView aufrufen. Dialog-Themes brauchen das nicht, sie werden
+	 * ohnehin nicht bis an den Bildschirmrand gezeichnet.
 	 */
 	public static void apply(Activity activity) {
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
 			return;
 		}
 		final View content = activity.findViewById(android.R.id.content);
+		if (content == null) {
+			return;
+		}
 		content.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
 			public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
-				// ime() mit einbeziehen, damit Eingabefelder nicht von der
-				// Tastatur verdeckt werden.
 				Insets bars = insets.getInsets(WindowInsets.Type.systemBars()
-						| WindowInsets.Type.displayCutout()
-						| WindowInsets.Type.ime());
+						| WindowInsets.Type.displayCutout());
 				v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
 				return WindowInsets.CONSUMED;
 			}

--- a/app/src/main/java/de/pskiwi/avrremote/LevelActivity.java
+++ b/app/src/main/java/de/pskiwi/avrremote/LevelActivity.java
@@ -173,6 +173,7 @@ public final class LevelActivity extends Activity {
 		zone = Zone.Main;
 
 		setContentView(R.layout.level);
+		EdgeToEdge.apply(this);
 
 		absoluteMode = AVRSettings.getVolumeDisplay(this) == VolumeDisplay.Absolute;
 		checkBoxLink = (CheckBox) findViewById(R.id.checkLinkChannels);

--- a/app/src/main/java/de/pskiwi/avrremote/OnScreenDisplayActivity.java
+++ b/app/src/main/java/de/pskiwi/avrremote/OnScreenDisplayActivity.java
@@ -125,6 +125,7 @@ public final class OnScreenDisplayActivity extends ListActivity implements
 		Logger.info("start screen" + screen);
 		screen.setActiveZoneState(zoneState);
 		setContentView(screen.getLayoutResource());
+		EdgeToEdge.apply(this);
 
 		screen.extendView(this, new IStatusComponentHandler() {
 			public void addView(View v, AtomicBoolean enable) {

--- a/app/src/main/java/de/pskiwi/avrremote/RenameActivity.java
+++ b/app/src/main/java/de/pskiwi/avrremote/RenameActivity.java
@@ -44,6 +44,7 @@ public final class RenameActivity extends ListActivity {
 		super.onCreate(savedInstanceState);
 		renameService = getApp().getRenameService();
 		setContentView(R.layout.rename);
+		EdgeToEdge.apply(this);
 		updateModel();
 		Spinner spinner = (Spinner) findViewById(R.id.categorySpinner);
 		spinner.setOnItemSelectedListener(new OnItemSelectedListener() {

--- a/app/src/main/java/de/pskiwi/avrremote/StatusbarManager.java
+++ b/app/src/main/java/de/pskiwi/avrremote/StatusbarManager.java
@@ -43,7 +43,7 @@ public final class StatusbarManager {
 		Intent notificationIntent = new Intent(app, appClass);
 		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
 		PendingIntent contentIntent = PendingIntent.getActivity(app, 0,
-				notificationIntent, 0);
+				notificationIntent, PendingIntent.FLAG_IMMUTABLE);
 
         // https://stackoverflow.com/questions/32345768/cannot-resolve-method-setlatesteventinfo
 		// https://developer.android.com/guide/topics/ui/notifiers/notifications.html

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,16 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:8.13.0'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+android.useAndroidX=false
+# R-Felder final halten, damit switch/case R.id.* in OptionsMenu.java weiter kompiliert
+android.nonFinalResIds=false
+org.gradle.jvmargs=-Xmx2048m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/local.properties
+++ b/local.properties
@@ -1,7 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-#
-#Sat Sep 05 17:16:29 CEST 2020
-sdk.dir=/home/andreas/Android/Sdk


### PR DESCRIPTION
Brings the build off the 2020 toolchain (AGP 4.1.1 / Gradle 6.7 / JDK 8, `jcenter()`) and up to `compileSdk`/`targetSdk` 36. Google Play requires targetSdk 36 for updates from 2026-08-30.

Kept deliberately minimal: **no AndroidX migration, no UI rewrite, no HTTP rewrite.** The app has no dependencies at all and no support-library imports, so there was nothing to migrate; `org.apache.http.legacy.jar` still ships with the android-36 platform, so the Apache HTTP code stays untouched.

## Toolchain

| | before | after |
|---|---|---|
| AGP | 4.1.1 | 8.13.0 |
| Gradle | 6.7 | 8.13 |
| JDK | 8 | 17 |
| compileSdk / targetSdk | 30 / 30 | 36 / 36 |
| minSdk | 8 | 24 |

Also: `jcenter()` → `mavenCentral()` (jcenter is shut down), pinned `buildToolsVersion` dropped, `lintOptions {}` → `lint {}`, manifest `package` attribute → `namespace`, and `local.properties` untracked (it pointed at a Linux SDK path).

New `gradle.properties` sets `android.nonFinalResIds=false`. This is load-bearing: AGP 8 makes `R` fields non-final by default, which would break the 15 `switch`/`case R.id.*` in `menu/OptionsMenu.java`. One line instead of rewriting that file.

## Required by targetSdk 36

- `android:exported` on all seven activities — a **build error** since targetSdk 31
- `PendingIntent.FLAG_IMMUTABLE` in `StatusbarManager` — throws `IllegalArgumentException` since 31
- `POST_NOTIFICATIONS` permission plus a runtime request in `AVRRemote`; without it the ongoing notification is dropped silently since 33
- new `EdgeToEdge` helper, called from the six non-dialog activities. Android 16 ignores `windowOptOutEdgeToEdgeEnforcement` at targetSdk 36, and none of the themes derive from an ActionBar variant, so content would otherwise draw under the system bars

## Verification

`./gradlew build` passes. Beyond that — note the repo has **no tests**, so everything below is manual:

Emulator, API 36:
- app starts, connects, no crash and no ANR over the whole session
- `am start` on a non-launcher activity is refused with `SecurityException: not exported` — confirms the manifest change
- notification permission prompt appears, notification is posted afterwards, tapping it opens the app (confirms `FLAG_IMMUTABLE`)
- keyboard does not cover the IP input dialog
- AVRRemote, AVRSettings, AboutActivity, LevelActivity, RenameActivity all sit correctly between the system bars

Pixel 8 on **Android 17 (SDK 37)**: installs, starts, connects to a real AVR-3310, layout correct.

`OnScreenDisplayActivity` was **not** exercised — reaching it needs receiver display data the test setup did not provide.

## Also in here

- `AVRApplication.onCreate()` never called `super.onCreate()`. Pre-existing bug, lint flagged it as an error but `abortOnError false` hid it. Separate commit.
- `CLAUDE.md` added.
- README updated for the new toolchain; its CI badge pointed at a workflow name that no longer exists (`Java CI with Gradle` vs. the actual `Check build`), so the badge was broken.

## Next

Local Network Protection becomes mandatory for apps targeting **Android 17 / SDK 37**, which hits `scan/AVRScanner` and the raw receiver sockets — the core of the app. Not an issue at targetSdk 36, but it is the next real piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014e3XPXuJ2xcuaviayZmhud