### PR TITLE
Docs: add TODO.md backlog, list supported models, correct factual errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,9 @@ Release builds are signed only when `~/keystore.properties` exists or the `KEY_A
    commands terminated with `\r`, and parses incoming lines into `InData`.
 2. **HTTP** — `http/AVRHTTPClient` scrapes the receiver's own web UI (`*.asp`, XML endpoints) for
    things the telnet protocol does not expose: input/zone names, quick-select presets, NET audio
-   search. `http/Series08*` parse the 2008-series variant. This is the only Apache-HTTP code left
-   (`useLibrary 'org.apache.http.legacy'`). Receivers speak plain HTTP, so
+   search. `http/Series08*` parse the 2008-series variant. Apache HTTP
+   (`useLibrary 'org.apache.http.legacy'`) survives in exactly three files: `http/AVRHTTPClient`,
+   `http/Series08Reader` and — easy to miss — `core/display/NetDisplay`. Receivers speak plain HTTP, so
    `android:usesCleartextTraffic="true"` in the manifest is load-bearing — removing it kills the
    whole scraping path.
 
@@ -64,23 +65,28 @@ ResilentConnector (daemon thread, reconnect loop)  ->  Connector (socket)
 `getModelConfigurator()`, `getDisplayManager()`, `getRenameService()`, `getMacroManager()` and more.
 Activities reach everything through `(AVRApplication) getApplication()`.
 
-`EnableManager` drives view enablement from a small set of `StatusFlag`s (`WLAN`, `Reachable`,
-`Connected`, `Power`, `Zone1`–`Zone4`). This is why most buttons are greyed out until a receiver is
-actually connected — worth knowing when testing without hardware.
+`EnableManager` drives view enablement from a small set of `StatusFlag`s (`Logging`, `WLAN`,
+`Reachable`, `Connected`, `Power`, `Zone1`–`Zone4`). This is why most buttons are greyed out until a
+receiver is actually connected — worth knowing when testing without hardware.
 
 `IStateFilter` decides which screen currently receives state updates, so background activities do not
 fight over the display listener.
 
-`core/display/` parses the receiver's on-screen display into `DisplayLine`s. `NetDisplay`,
-`TunerDisplay` and `BDDisplay` are three separate, large parsers for different input types.
+`core/display/` parses the receiver's on-screen display into `DisplayLine`s. `NetDisplay` (1182
+lines), `TunerDisplay` (1059) and `BDDisplay` (393) are three separate parsers for different input
+types.
 
 Up to 4 zones and up to 3 receivers are supported; the receiver index threads through
 `AVRSettings.getAVRModel(ctx, receiverNr)` and the `receiverSuffix()` preference-key convention.
 
 ### Receiver models — reflection registry
 
-`models/` holds 67 classes, one per receiver family, all extending `AbstractModel` and overriding
-capability predicates (`hasZones()`, `hasQuick()`, `getSupportedLevels()`, `supportsDAB()`, …).
+`models/` holds **60 receiver classes**, one per receiver family, each overriding capability
+predicates (`hasZones()`, `hasQuick()`, `getSupportedLevels()`, `supportsDAB()`, …). The directory
+has 67 `.java` files — the other seven are infrastructure: `AbstractModel`, `AbstractMarantzAV`,
+`IAVRModel`, `ModelArea`, `ModelConfigurator` and the two `DynamicEQ*` enums. All 60 reach
+`AbstractModel`, but only 33 extend it directly; the rest go through `AbstractMarantzAV` or another
+model class (`AVR990 extends AVR3310`, `AVCA1HDA extends AVR5308`, …).
 
 `ModelConfigurator.update()` resolves the model **by reflection** from the user's preference string:
 
@@ -94,6 +100,9 @@ to `AVRGeneric` — silent to the user, but visible in the log.
 Consequences:
 - Adding a receiver needs **two** changes: a class in `models/` *and* an entry in
   `@array/modelNames` in `res/values/lists.xml`. The names must correspond after dash-stripping.
+  Both sides currently hold exactly 60 entries and resolve 1:1 — if they drift apart, the orphaned
+  name falls back to `AVRGeneric` and the user just silently misses features. (Note `lists.xml` holds
+  130 `<item>`s across 14 arrays; only the 60 in `modelNames` are receivers.)
 - The model classes have no static references. Never enable R8/ProGuard shrinking without a
   keep rule for `de.pskiwi.avrremote.models.**`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Android remote control for Denon and Marantz AV receivers (`de.pskiwi.avrremote`, GPL v3).
 Talks to receivers on the local network — there is no backend and no account.
 
+**[TODO.md](TODO.md) is the backlog** — known-broken behaviour, the next platform deadline, and the
+housekeeping items, each with file and line. Read it before proposing work of your own; what looks
+like an oversight is usually already listed there with the reason it was left alone. When you finish
+one of the items, tick its checkbox in the same commit.
+
 ## Build and run
 
 The build needs **JDK 17** and **Android SDK Platform 36**:
@@ -126,7 +131,8 @@ Three things are easy to forget and all are required at `targetSdk 36`:
 
 ## Known-broken, pre-existing
 
-Do not treat these as regressions; they predate the SDK 36 upgrade:
+Do not treat these as regressions; they predate the SDK 36 upgrade. Fixes are tracked in
+[TODO.md](TODO.md) → *Broken today*:
 
 - `log/SDLogger` writes to `Environment.getExternalStorageDirectory()` — fails under scoped storage
   since Android 10. `WRITE_EXTERNAL_STORAGE` in the manifest has been a no-op since Android 11.
@@ -140,4 +146,5 @@ Do not treat these as regressions; they predate the SDK 36 upgrade:
 Local Network Protection becomes mandatory for apps targeting **Android 17 (SDK 37)**. That directly
 hits `scan/AVRScanner` (subnet sweep) and the raw receiver sockets — i.e. the core of the app. At
 `targetSdk 36` it does not apply yet, but plan for a runtime local-network permission before raising
-the target further.
+the target further. See [TODO.md](TODO.md) → *Next platform deadline: targetSdk 37* for the deprecated
+`WifiManager` calls to replace in the same pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ Release builds are signed only when `~/keystore.properties` exists or the `KEY_A
 2. **HTTP** — `http/AVRHTTPClient` scrapes the receiver's own web UI (`*.asp`, XML endpoints) for
    things the telnet protocol does not expose: input/zone names, quick-select presets, NET audio
    search. `http/Series08*` parse the 2008-series variant. This is the only Apache-HTTP code left
-   (`useLibrary 'org.apache.http.legacy'`).
+   (`useLibrary 'org.apache.http.legacy'`). Receivers speak plain HTTP, so
+   `android:usesCleartextTraffic="true"` in the manifest is load-bearing — removing it kills the
+   whole scraping path.
 
 ### State flow
 
@@ -81,7 +83,8 @@ capability predicates (`hasZones()`, `hasQuick()`, `getSupportedLevels()`, `supp
 "AVR-3310"  --strip "-"--> "AVR3310"  -->  Class.forName("de.pskiwi.avrremote.models.AVR3310")
 ```
 
-A trailing `(experimental)` is stripped too, and any failure silently falls back to `AVRGeneric`.
+A trailing `(experimental)` is stripped too, and any failure logs via `Logger.error` and falls back
+to `AVRGeneric` — silent to the user, but visible in the log.
 
 Consequences:
 - Adding a receiver needs **two** changes: a class in `models/` *and* an entry in
@@ -98,6 +101,11 @@ Consequences:
   `PreferenceActivity`, `TabHost`/`TabWidget` layouts, and pre-Holo platform themes
   (`Theme.NoTitleBar`, plus `Theme.Light` and `Theme.Dialog` used directly from the manifest).
   They still compile; match the surrounding style rather than modernising piecemeal.
+- **JDK 17 builds the project, but the source level is Java 11** (`sourceCompatibility`/
+  `targetCompatibility VERSION_11`). No records (16), no switch expressions (14), no text blocks (15)
+  — Java 11 syntax only.
+- `minSdk 24`. Anything newer needs a `Build.VERSION.SDK_INT` guard. Lint reports this as `NewApi`,
+  but `abortOnError false` means the build still succeeds — it will only fail on the device.
 - Indentation is tabs. Comments are a mix of German and English.
 - `android.nonFinalResIds=false` in `gradle.properties` is load-bearing: it keeps `R` fields final so
   the `switch`/`case R.id.*` in `menu/OptionsMenu.java` compiles. Do not remove it without rewriting
@@ -105,7 +113,7 @@ Consequences:
 
 ### When adding an Activity
 
-Two things are easy to forget and both are required at `targetSdk 36`:
+Three things are easy to forget and all are required at `targetSdk 36`:
 
 1. `android:exported` in the manifest. For a component **with** an intent filter, omitting it is a
    build error; without a filter it is optional but set explicitly here for consistency.

--- a/README.md
+++ b/README.md
@@ -17,22 +17,22 @@ Picked in the app under *Settings → Model Settings → Model*. The choice deci
 offered (number of zones, quick-select, level controls, DAB, …), so it is worth setting even when a
 similar model appears to work.
 
-**Denon (36)**
+**Denon (39)**
 
 AVC-A1HDA, AVP-A1HDCI, AVR-100, AVR-990, AVR-991, AVR-1613, AVR-1713, AVR-1912, AVR-1913, AVR-2112,
 AVR-2113, AVR-2312, AVR-2313, AVR-3310, AVR-3311, AVR-3312, AVR-3313, AVR-3805, AVR-3806, AVR-3808,
 AVR-4306, AVR-4308, AVR-4310, AVR-4311, AVR-4520, AVR-4806, AVR-4810, AVR-5308, AVR-5805, AVR-E300,
 AVR-E400, AVR-X1000, AVR-X2000, AVR-X3000, AVR-X4000, DN-500AV
 
-**Marantz (17)**
+Network and media players: ASD-51 *(experimental)*, DNP-720AE, RCD-N7 *(experimental)*
+
+**Marantz (20)**
 
 AV-7005, AV-7701, AV-8801, NR-1504, NR-1602, NR-1603, NR-1604, SR-5006, SR-5007, SR-5008, SR-6005,
 SR-6006, SR-6007, SR-6008, SR-7005, SR-7007, SR-7008
 
-**Network and media players (6)**
-
-ASD-51 *(experimental)*, DNP-720AE, M-CR603 *(experimental)*, M-ER803 *(experimental)*,
-NA-7004 *(experimental)*, RCD-N7 *(experimental)*
+Network and media players: M-CR603 *(experimental)*, M-ER803 *(experimental)*,
+NA-7004 *(experimental)*
 
 Not listed? **AVR-Generic** is the fallback and speaks the common subset of the protocol — usually
 enough for power, volume, mute and input selection.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ Denon and Marantz are registered trademarks of D&M Holdings, Inc.
 
 Runs on Android 7.0 (API 24) and newer.
 
+## Supported models
+
+Picked in the app under *Settings → Model Settings → Model*. The choice decides which features are
+offered (number of zones, quick-select, level controls, DAB, …), so it is worth setting even when a
+similar model appears to work.
+
+**Denon (36)**
+
+AVC-A1HDA, AVP-A1HDCI, AVR-100, AVR-990, AVR-991, AVR-1613, AVR-1713, AVR-1912, AVR-1913, AVR-2112,
+AVR-2113, AVR-2312, AVR-2313, AVR-3310, AVR-3311, AVR-3312, AVR-3313, AVR-3805, AVR-3806, AVR-3808,
+AVR-4306, AVR-4308, AVR-4310, AVR-4311, AVR-4520, AVR-4806, AVR-4810, AVR-5308, AVR-5805, AVR-E300,
+AVR-E400, AVR-X1000, AVR-X2000, AVR-X3000, AVR-X4000, DN-500AV
+
+**Marantz (17)**
+
+AV-7005, AV-7701, AV-8801, NR-1504, NR-1602, NR-1603, NR-1604, SR-5006, SR-5007, SR-5008, SR-6005,
+SR-6006, SR-6007, SR-6008, SR-7005, SR-7007, SR-7008
+
+**Network and media players (6)**
+
+ASD-51 *(experimental)*, DNP-720AE, M-CR603 *(experimental)*, M-ER803 *(experimental)*,
+NA-7004 *(experimental)*, RCD-N7 *(experimental)*
+
+Not listed? **AVR-Generic** is the fallback and speaks the common subset of the protocol — usually
+enough for power, volume, mute and input selection.
+
 ## Required Tools
 
 * JDK 17

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,90 @@
+# TODO
+
+Things worth doing, roughly in the order they will hurt if left alone.
+Everything here was found while moving the build to SDK 36 in July 2026; none of it
+blocks the current build, which is green.
+
+## Broken today
+
+- [ ] **Sending logs does not work.** `SDLogger.getLogURI()` returns a `file://` URI,
+      `log/FeedbackReporter.java:93` puts it into `Intent.EXTRA_STREAM` → `FileUriExposedException`
+      since targetSdk 24. This is the app's own support channel ("Feedback" in the options menu).
+      Fix: add a `FileProvider` and hand out a content URI.
+- [ ] **`SDLogger` writes to `Environment.getExternalStorageDirectory()`**, which fails under
+      scoped storage (Android 10+). Move to `getExternalFilesDir(null)`.
+- [ ] Once both are done, drop `WRITE_EXTERNAL_STORAGE` from the manifest — it has been a no-op
+      since Android 11. (Until then it should at least carry `android:maxSdkVersion="28"`.)
+
+## Next platform deadline: targetSdk 37
+
+- [ ] **Local Network Protection becomes mandatory** for apps targeting Android 17. It affects the
+      core of this app: the subnet sweep in `scan/AVRScanner` and the raw sockets to the receiver.
+      Needs the new local-network runtime permission and a rationale UI.
+- [ ] Same area, do it in one pass: `scan/WiFiInfo` relies on `WifiManager.getDhcpInfo()` (netmask
+      and local IP for the sweep) and `ConnectivityManager.getNetworkInfo(TYPE_WIFI)`, plus
+      `AVRApplication.java:63`. Both deprecated (API 31 / 29) → `NetworkCallback` and
+      `NetworkCapabilities`.
+
+## Structural
+
+- [ ] **There are no tests at all.** Highest-value first test, because it covers a failure mode the
+      compiler cannot see: `models/ModelConfigurator` resolves the 67 receiver classes **by
+      reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
+      entry in `res/values/lists.xml` drift and there is no build error — the app silently falls
+      back to `AVRGeneric` and the user just misses features. A JVM unit test that runs all 130
+      entries of `@array/modelNames` through the same normalisation and instantiates them catches
+      exactly that.
+- [ ] After that, `models/` (pure capability logic) and `core/ZoneState.java` (1237 lines) are the
+      cheapest places to add coverage.
+- [ ] **The receiver connection lives on a daemon thread owned by `AVRApplication`, not a Service.**
+      A design decision from 2010. Under modern background restrictions the process can be reclaimed
+      and the connection dies with it. This is the most likely cause of "the app just stops
+      responding" reports.
+
+## Time bomb, no fuse length known
+
+- [ ] **Apache HTTP** in `http/AVRHTTPClient`, `http/Series08Reader` and `core/display/NetDisplay`
+      (49 references). Works today: `org.apache.http.legacy.jar` still ships with the android-36
+      platform, and since only cleartext HTTP on the LAN is spoken, the ancient TLS stack does not
+      matter. The risk is purely that Google drops the optional library from some future platform,
+      turning this into unplanned work. It is only GET/POST with form bodies — `HttpURLConnection`
+      would do.
+
+## Housekeeping
+
+- [ ] **Gradle 10 syntax**: `./gradlew --warning-mode all` flags exactly two spots —
+      `namespace "…"` and `abortOnError false` need `=` assignment. Two characters.
+- [ ] `versionCode` (124) and `versionName` (1.5.1) still sit in the manifest unchanged and must be
+      raised before any release. The release workflow triggers on a `v*` tag and needs the
+      `KEY_JKS`, `KEY_PASSWORD`, `KEY_ALIAS` and `STORE_PASSWORD` secrets.
+- [ ] `misc/add-copyright.sh` and `misc/createicons.sh` still use pre-Gradle paths (`../src/...`
+      instead of `app/src/main/...`). `createicons.sh` overwrites icons, so running it from the
+      wrong directory is destructive.
+- [ ] Lint reports 48 unused resources and 30 missing German translations.
+      `res/values-v14/dimension.xml` holds a single `widget_margin` left over from an app widget
+      that no longer exists.
+- [ ] `allowBackup="true"` without `dataExtractionRules`. Not a bug — the API 31 default backs
+      everything up, including receiver IPs in the SharedPreferences — but an explicit rule would be
+      cleaner.
+- [ ] Dead version check: `StatusbarManager.java:50` gates on `SDK_INT >= JELLY_BEAN`, always true
+      at minSdk 24. The `if` wraps the whole method body.
+
+## Large, no deadline
+
+- [ ] **UI modernisation**: AndroidX/AppCompat, `TabActivity` / `ListActivity` /
+      `ExpandableListActivity` / `PreferenceActivity` → Fragments and `androidx.preference`,
+      `AsyncTask` (5 files) → executors, `ProgressDialog` (4 files) → inline progress,
+      `startActivityForResult` → Activity Result API, 12× `new Handler()` → `Handler(Looper)`.
+      All deprecated, all still compiles. Worth doing only when the look is to change — at which
+      point it is unavoidable, because the pre-Holo platform themes do not allow modern styling.
+- [ ] The custom-background picker (`AVRSettings.java:62`) stores the picked URI without
+      `takePersistableUriPermission()`, so it does not survive a restart. Part of the same
+      Activity-Result-API rewrite.
+- [ ] `OnScreenDisplayActivity` was never exercised during the SDK 36 verification — reaching it
+      needs receiver display data. Worth a manual pass on a real receiver.
+
+## Open question
+
+- [ ] The README links to the **Google Play Store**, but the release workflow builds an APK for
+      GitHub Releases. If the app is still maintained on Play, check whether an App Bundle is now
+      required there instead of an APK.

--- a/TODO.md
+++ b/TODO.md
@@ -22,18 +22,19 @@ blocks the current build, which is green.
       Needs the new local-network runtime permission and a rationale UI.
 - [ ] Same area, do it in one pass: `scan/WiFiInfo` relies on `WifiManager.getDhcpInfo()` (netmask
       and local IP for the sweep) and `ConnectivityManager.getNetworkInfo(TYPE_WIFI)`, plus
-      `AVRApplication.java:63`. Both deprecated (API 31 / 29) → `NetworkCallback` and
+      `AVRApplication.java:63`. Both deprecated — `getDhcpInfo()` since API 31, the
+      `getNetworkInfo(int)` overload used here already since API 23 → `NetworkCallback` and
       `NetworkCapabilities`.
 
 ## Structural
 
 - [ ] **There are no tests at all.** Highest-value first test, because it covers a failure mode the
-      compiler cannot see: `models/ModelConfigurator` resolves the 67 receiver classes **by
+      compiler cannot see: `models/ModelConfigurator` resolves the 60 receiver classes **by
       reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
       entry in `res/values/lists.xml` drift and there is no build error — the app silently falls
-      back to `AVRGeneric` and the user just misses features. A JVM unit test that runs all 130
+      back to `AVRGeneric` and the user just misses features. A JVM unit test that runs all 60
       entries of `@array/modelNames` through the same normalisation and instantiates them catches
-      exactly that.
+      exactly that. Both sides hold 60 entries today, so the test starts green.
 - [ ] After that, `models/` (pure capability logic) and `core/ZoneState.java` (1237 lines) are the
       cheapest places to add coverage.
 - [ ] **The receiver connection lives on a daemon thread owned by `AVRApplication`, not a Service.**
@@ -44,7 +45,7 @@ blocks the current build, which is green.
 ## Time bomb, no fuse length known
 
 - [ ] **Apache HTTP** in `http/AVRHTTPClient`, `http/Series08Reader` and `core/display/NetDisplay`
-      (49 references). Works today: `org.apache.http.legacy.jar` still ships with the android-36
+      (26 `org.apache.http` imports across the three). Works today: `org.apache.http.legacy.jar` still ships with the android-36
       platform, and since only cleartext HTTP on the LAN is spoken, the ancient TLS stack does not
       matter. The risk is purely that Google drops the optional library from some future platform,
       turning this into unplanned work. It is only GET/POST with form bodies — `HttpURLConnection`
@@ -57,17 +58,23 @@ blocks the current build, which is green.
 - [ ] `versionCode` (124) and `versionName` (1.5.1) still sit in the manifest unchanged and must be
       raised before any release. The release workflow triggers on a `v*` tag and needs the
       `KEY_JKS`, `KEY_PASSWORD`, `KEY_ALIAS` and `STORE_PASSWORD` secrets.
-- [ ] `misc/add-copyright.sh` and `misc/createicons.sh` still use pre-Gradle paths (`../src/...`
-      instead of `app/src/main/...`). `createicons.sh` overwrites icons, so running it from the
-      wrong directory is destructive.
+- [ ] `misc/add-copyright.sh` still uses the pre-Gradle path (`../src/**/*.java` instead of
+      `app/src/main/...`), so it currently matches nothing.
+- [ ] `misc/createicons.sh` looks obsolete and should probably just be deleted: it writes 46 plain
+      red placeholder squares (`convert -size 32x32 canvas:red …`) to `res/...` relative to the
+      **current** directory. Run from `misc/` or the repo root it only creates a stray `res/` tree;
+      run from `app/src/main` it would overwrite the real icons with red squares. `misc/mkicons.sh`
+      is the maintained script and already uses the Gradle path (`TGT=../app/src/main/res`).
 - [ ] Lint reports 48 unused resources and 30 missing German translations.
-      `res/values-v14/dimension.xml` holds a single `widget_margin` left over from an app widget
-      that no longer exists.
+      `res/values-v14/dimension.xml` holds a single `widget_margin`, a left-over override of
+      `res/values/dimension.xml:27` from an app widget that no longer exists; lint also flags the
+      whole `-v14` qualifier as pointless at minSdk 24.
 - [ ] `allowBackup="true"` without `dataExtractionRules`. Not a bug — the API 31 default backs
       everything up, including receiver IPs in the SharedPreferences — but an explicit rule would be
       cleaner.
 - [ ] Dead version check: `StatusbarManager.java:50` gates on `SDK_INT >= JELLY_BEAN`, always true
-      at minSdk 24. The `if` wraps the whole method body.
+      at minSdk 24 (lint: `ObsoleteSdkInt`). The `if` wraps lines 51–74; the `Context`/`Intent`/
+      `PendingIntent` setup above it stays.
 
 ## Large, no deadline
 
@@ -77,9 +84,10 @@ blocks the current build, which is green.
       `startActivityForResult` → Activity Result API, 12× `new Handler()` → `Handler(Looper)`.
       All deprecated, all still compiles. Worth doing only when the look is to change — at which
       point it is unavoidable, because the pre-Holo platform themes do not allow modern styling.
-- [ ] The custom-background picker (`AVRSettings.java:62`) stores the picked URI without
-      `takePersistableUriPermission()`, so it does not survive a restart. Part of the same
-      Activity-Result-API rewrite.
+- [ ] The custom-background picker stores the picked URI (`AVRSettings.java:92`, listener registered
+      at `:62`) without `takePersistableUriPermission()`, so it does not survive a restart. Note the
+      fix is not just an added call: the picker uses `ACTION_PICK`, and persistable permissions need
+      `ACTION_OPEN_DOCUMENT`. Part of the same Activity-Result-API rewrite.
 - [ ] `OnScreenDisplayActivity` was never exercised during the SDK 36 verification — reaching it
       needs receiver display data. Worth a manual pass on a real receiver.
 

--- a/app/src/main/java/de/pskiwi/avrremote/models/ASD51.java
+++ b/app/src/main/java/de/pskiwi/avrremote/models/ASD51.java
@@ -20,7 +20,7 @@ import de.pskiwi.avrremote.EnableManager.StatusFlag;
 import de.pskiwi.avrremote.core.Selection;
 import de.pskiwi.avrremote.core.SelectionBuilder;
 
-/** MARANTZ Media Player */
+/** DENON Media Player */
 public class ASD51 extends AbstractModel {
 
 	public Selection getInputSelection(ModelArea area) {

--- a/app/src/main/java/de/pskiwi/avrremote/models/DNP720AE.java
+++ b/app/src/main/java/de/pskiwi/avrremote/models/DNP720AE.java
@@ -21,7 +21,7 @@ import de.pskiwi.avrremote.EnableManager.StatusFlag;
 import de.pskiwi.avrremote.core.Selection;
 import de.pskiwi.avrremote.core.SelectionBuilder;
 
-/** MARANTZ Media Player */
+/** DENON Media Player */
 public class DNP720AE extends AbstractModel {
 
 	public Selection getInputSelection(ModelArea area) {


### PR DESCRIPTION
Documentation pass over `CLAUDE.md`, plus a new `TODO.md` and a supported-model list in the README. One two-line code change, comments only — no behaviour change anywhere.

## What's in here

**`TODO.md` (new)** — the backlog collected while moving the build to SDK 36: what is broken today, the targetSdk 37 local-network deadline, the missing tests, and the housekeeping items, each with file and line. `CLAUDE.md` links to it from three places so it gets found before someone re-derives an item as if it were new.

**`README.md`** — the 59 supported models plus `AVR-Generic` were previously only visible in the app's settings dropdown or by reading `res/values/lists.xml`. Now grouped by brand, with the five entries the app labels experimental marked as such.

**`CLAUDE.md`** — documents the Java 11 source level and `minSdk 24` (JDK 17 builds the project, but newer language features and API calls fail only on the device, since `NewApi` lint does not abort the build), and `usesCleartextTraffic` as load-bearing for the HTTP scraping path.

**`ASD51.java` / `DNP720AE.java`** — both carried a copy-pasted `/** MARANTZ Media Player */` comment despite being Denon models. Comment text only.

## Corrections

A verification pass against the code turned up several claims that did not hold:

| Claim | Actual |
|---|---|
| "67 receiver classes" | 60 — the other seven `.java` files are infrastructure |
| "130 entries of `@array/modelNames`" | 60; 130 was the item count across all 14 arrays in `lists.xml` |
| Apache HTTP lives in `http/` | also `core/display/NetDisplay`, which `CLAUDE.md` and `TODO.md` disagreed about |
| `getNetworkInfo(int)` deprecated in API 29 | API 23 |
| `createicons.sh` destructive from the wrong directory | inverted — it writes relative to the CWD, so the *right* directory is the dangerous one. It also only emits red placeholders and is superseded by `mkicons.sh` |
| "49 Apache references" | matched no counting method; replaced with the 26 imports |
| `AVRSettings.java:62` stores the URI | `:62` is the listener, `:92` stores it |

The 60-classes correction is the useful one: `models/` and `@array/modelNames` both hold exactly 60 entries and resolve 1:1, which makes the reflection coupling checkable. `CLAUDE.md` now states that as a rule.

Also corrected: the `StatusFlag` list (missing `Logging`), the `BDDisplay` "large parser" claim (393 lines vs 1182/1059), the `AbstractModel` inheritance description (only 33 of 60 extend it directly), the `StatusbarManager` line range, and the `values-v14` override note.

## Verification

The README model list was diffed mechanically against `@array/modelNames` — 59 to 59, identical, experimental markers included. Numbers in both docs were counted against the source rather than carried over.

Not verified on a device: this repo has no tests, and nothing here changes runtime behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014giHE91wz6JQtqWPgYSwzY