### PR TITLE
Replace Apache HttpClient with HttpURLConnection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,8 @@ Consequences:
   pattern is still in 13 places (`core/Connector`, `core/MacroManager`, `log/FeedbackReporter`,
   `log/SDLogger`, the three `http/Series08*Parser`, `core/RenameService`, `scan/AVRTargetTester`);
   converting one is welcome when you are editing that code anyway, but do not sweep the tree as a
-  side errand. The one reason to keep the manual form is when
+  side errand — and note `core/Connector.java:168` is not convertible at all, it closes the socket
+  only on the failure path (`if (!ok)`). The other reason to keep the manual form is when
   an exception from `close()` must be swallowed deliberately — see
   `HTTPSupportTest.serveOneRequest`, where letting it propagate would fake a test failure.
   This does **not** extend to the UI bases above: those are a migration, not a style choice.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,14 +28,21 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
 **There is almost no test coverage.** `src/test` holds two JVM test classes —
-`http/HTTPSupportTest` (6 cases) and `http/AVRXMLInfoParserTest` (1 case), JUnit 4 being the only
+`http/HTTPSupportTest` (7 cases) and `http/AVRXMLInfoParserTest` (1 case), JUnit 4 being the only
 dependency in the project — and there is no `src/androidTest` at all. `./gradlew test` runs those
-seven cases and nothing else, so do not report a change as verified because the build passed; verify
-on a device or emulator instead. Note that `http/AVRXMLInfoParser` cannot be exercised from a JVM
-test at all: it reads only SAX `localName`, which stays empty on a standard non-namespace-aware
-`SAXParserFactory`. Android's Expat-based parser fills it anyway, which is the only reason the
-scraping path works. Lint runs with
-`abortOnError false`, so lint *errors* do not fail the build — check
+eight cases and nothing else (twice, in fact: once per build variant), so do not report a change as
+verified because the build passed; verify on a device or emulator instead. Two limits are worth
+knowing before writing more tests:
+
+- These run on the desktop JVM, not on Android's OkHttp-backed stack. Anything Android-specific —
+  the implicit `Accept-Encoding: gzip`, chunked request bodies — cannot be pinned here, only
+  documented. `HTTPSupportTest` says so at the assertions concerned.
+- `http/AVRXMLInfoParser` cannot be driven from a JVM test without changing the class: it reads only
+  SAX `localName`, which stays empty on a standard non-namespace-aware `SAXParserFactory`. Android's
+  Expat-based parser fills it anyway, which is the only reason the scraping path works. Same pattern
+  in `core/RenameService`.
+
+Lint runs with `abortOnError false`, so lint *errors* do not fail the build — check
 `app/build/reports/lint-results-debug.html` explicitly when it matters.
 
 Release builds are signed only when `~/keystore.properties` exists or the `KEY_ALIAS` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,16 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
-**There are no tests.** No `src/test`, no `src/androidTest`, no test dependencies. `./gradlew test`
-succeeds but runs nothing. Do not report a change as verified because the build passed; verify on a
-device or emulator instead. Lint runs with `abortOnError false`, so lint *errors* do not fail the
-build — check `app/build/reports/lint-results-debug.html` explicitly when it matters.
+**There is almost no test coverage.** `src/test` holds two JVM test classes —
+`http/HTTPSupportTest` (6 cases) and `http/AVRXMLInfoParserTest` (1 case), JUnit 4 being the only
+dependency in the project — and there is no `src/androidTest` at all. `./gradlew test` runs those
+seven cases and nothing else, so do not report a change as verified because the build passed; verify
+on a device or emulator instead. Note that `http/AVRXMLInfoParser` cannot be exercised from a JVM
+test at all: it reads only SAX `localName`, which stays empty on a standard non-namespace-aware
+`SAXParserFactory`. Android's Expat-based parser fills it anyway, which is the only reason the
+scraping path works. Lint runs with
+`abortOnError false`, so lint *errors* do not fail the build — check
+`app/build/reports/lint-results-debug.html` explicitly when it matters.
 
 Release builds are signed only when `~/keystore.properties` exists or the `KEY_ALIAS` /
 `KEY_PASSWORD` / `STORE_FILE` / `STORE_PASSWORD` env vars are set; otherwise
@@ -44,10 +50,13 @@ Release builds are signed only when `~/keystore.properties` exists or the `KEY_A
    commands terminated with `\r`, and parses incoming lines into `InData`.
 2. **HTTP** — `http/AVRHTTPClient` scrapes the receiver's own web UI (`*.asp`, XML endpoints) for
    things the telnet protocol does not expose: input/zone names, quick-select presets, NET audio
-   search. `http/Series08*` parse the 2008-series variant. Apache HTTP
-   (`useLibrary 'org.apache.http.legacy'`) survives in exactly three files: `http/AVRHTTPClient`,
-   `http/Series08Reader` and — easy to miss — `core/display/NetDisplay`. Receivers speak plain HTTP, so
-   `android:usesCleartextTraffic="true"` in the manifest is load-bearing — removing it kills the
+   search. `http/Series08*` parse the 2008-series variant. Every request goes through
+   `http/HTTPSupport` (`HttpURLConnection`, GET and form POST, nothing else); its three callers are
+   `http/AVRHTTPClient`, `http/Series08Reader` and — easy to miss — `core/display/NetDisplay`.
+   Two settings there are deliberate and load-bearing against the receivers' 2008-era GoAhead
+   webservers: `Accept-Encoding: identity` (the old Apache client never asked for gzip) and
+   `setFixedLengthStreamingMode` (so the body is never sent chunked). Receivers speak plain HTTP, so
+   `android:usesCleartextTraffic="true"` in the manifest is load-bearing too — removing it kills the
    whole scraping path.
 
 ### State flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,21 @@ Release builds are signed only when `~/keystore.properties` exists or the `KEY_A
    search. `http/Series08*` parse the 2008-series variant. Every request goes through
    `http/HTTPSupport` (`HttpURLConnection`, GET and form POST, nothing else); its three callers are
    `http/AVRHTTPClient`, `http/Series08Reader` and — easy to miss — `core/display/NetDisplay`.
-   Two settings there are deliberate and load-bearing against the receivers' 2008-era GoAhead
-   webservers: `Accept-Encoding: identity` (the old Apache client never asked for gzip) and
-   `setFixedLengthStreamingMode` (so the body is never sent chunked). Receivers speak plain HTTP, so
-   `android:usesCleartextTraffic="true"` in the manifest is load-bearing too — removing it kills the
-   whole scraping path.
+   Three things there are deliberate and load-bearing against the receivers' 2008-era GoAhead
+   webservers, and all three look removable to someone who does not know why they exist:
+
+   - `Accept-Encoding: identity` — the old Apache client never asked for gzip, Android does.
+   - `setFixedLengthStreamingMode` — so the request body is never sent chunked.
+   - `CookieHandler.setDefault(new CookieManager())` in `AVRApplication.onCreate`. The receivers
+     tested so far send no `Set-Cookie` at all, so this looks pointless — but `Series08Reader`
+     fetches `r_option1.asp` purely to establish state that the following `d_option1.asp` reads
+     back, and the Apache client it replaced carried a cookie store. Without a handler
+     `HttpURLConnection` shares nothing between requests, and the failure would be silent (empty
+     quick-select names). `readSeries08Info()` clears the store per run, because the old store was
+     per-client and did not outlive one read.
+
+   Receivers speak plain HTTP, so `android:usesCleartextTraffic="true"` in the manifest is
+   load-bearing too — removing it kills the whole scraping path.
 
 ### State flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,12 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
-**There is almost no test coverage.** `src/test` holds two JVM test classes —
-`http/HTTPSupportTest` (7 cases) and `http/AVRXMLInfoParserTest` (1 case), JUnit 4 being the only
-dependency in the project — and there is no `src/androidTest` at all. `./gradlew test` runs those
-eight cases and nothing else (twice, in fact: once per build variant), so do not report a change as
-verified because the build passed; verify on a device or emulator instead. Two limits are worth
-knowing before writing more tests:
+**There is almost no test coverage.** `src/test` holds three JVM test classes —
+`http/HTTPSupportTest` (7 cases), `http/Series08ParserTest` (5) and `http/AVRXMLInfoParserTest` (1),
+JUnit 4 being the only dependency in the project — and there is no `src/androidTest` at all.
+`./gradlew test` runs those thirteen cases and nothing else (twice, in fact: once per build
+variant), so do not report a change as verified because the build passed; verify on a device or
+emulator instead. Two limits are worth knowing before writing more tests:
 
 - These run on the desktop JVM, not on Android's OkHttp-backed stack. Anything Android-specific —
   the implicit `Accept-Encoding: gzip`, chunked request bodies — cannot be pinned here, only
@@ -40,7 +40,10 @@ knowing before writing more tests:
 - `http/AVRXMLInfoParser` cannot be driven from a JVM test without changing the class: it reads only
   SAX `localName`, which stays empty on a standard non-namespace-aware `SAXParserFactory`. Android's
   Expat-based parser fills it anyway, which is the only reason the scraping path works. Same pattern
-  in `core/RenameService`.
+  in `core/RenameService`. Its XXE hardening is Android-specific for the same reason: Android's
+  `SAXParserFactoryImpl` rejects `disallow-doctype-decl` with `SAXNotRecognizedException`, so the
+  parser disables `external-general-entities` and `external-parameter-entities` instead — those two
+  are supported. Verified on a Pixel 8; do not "simplify" it to the usual one-liner.
 
 Lint runs with `abortOnError false`, so lint *errors* do not fail the build — check
 `app/build/reports/lint-results-debug.html` explicitly when it matters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,16 @@ Consequences:
 - **JDK 17 builds the project, but the source level is Java 11** (`sourceCompatibility`/
   `targetCompatibility VERSION_11`). No records (16), no switch expressions (14), no text blocks (15)
   — Java 11 syntax only.
+- **Within Java 11, write modern Java.** The code dates from 2010 and mostly predates it, but new and
+  touched code should not imitate that. In particular use **try-with-resources** rather than the
+  manual `try { … } finally { x.close(); }` pattern — `http/HTTPSupport` is the reference. The old
+  pattern is still in 13 places (`core/Connector`, `core/MacroManager`, `log/FeedbackReporter`,
+  `log/SDLogger`, the three `http/Series08*Parser`, `core/RenameService`, `scan/AVRTargetTester`);
+  converting one is welcome when you are editing that code anyway, but do not sweep the tree as a
+  side errand. The one reason to keep the manual form is when
+  an exception from `close()` must be swallowed deliberately — see
+  `HTTPSupportTest.serveOneRequest`, where letting it propagate would fake a test failure.
+  This does **not** extend to the UI bases above: those are a migration, not a style choice.
 - `minSdk 24`. Anything newer needs a `Build.VERSION.SDK_INT` guard. Lint reports this as `NewApi`,
   but `abortOnError false` means the build still succeeds — it will only fail on the device.
 - Indentation is tabs. Comments are a mix of German and English.

--- a/TODO.md
+++ b/TODO.md
@@ -28,9 +28,9 @@ blocks the current build, which is green.
 
 ## Structural
 
-- [ ] **Test coverage is two files.** `http/HTTPSupportTest` and `http/AVRXMLInfoParserTest` (added
-      with the Apache removal) set up `src/test` and the JUnit dependency; everything else is still
-      uncovered. The highest-value test to add next is one for `models/ModelConfigurator`, because it
+- [ ] **Test coverage is three files.** `http/HTTPSupportTest`, `http/Series08ParserTest` and
+      `http/AVRXMLInfoParserTest` (added with the Apache removal) set up `src/test` and the JUnit
+      dependency; everything else is still uncovered. The highest-value test to add next is one for `models/ModelConfigurator`, because it
       covers a failure mode the compiler cannot see: it resolves the 60 receiver classes **by
       reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
       entry in `res/values/lists.xml` drift and there is no build error — the app silently falls

--- a/TODO.md
+++ b/TODO.md
@@ -79,6 +79,12 @@ blocks the current build, which is green.
 - [ ] `versionCode` (124) and `versionName` (1.5.1) still sit in the manifest unchanged and must be
       raised before any release. The release workflow triggers on a `v*` tag and needs the
       `KEY_JKS`, `KEY_PASSWORD`, `KEY_ALIAS` and `STORE_PASSWORD` secrets.
+- [ ] **13 manual `try { … } finally { close(); }` blocks left** in `core/Connector`,
+      `core/MacroManager`, `core/RenameService`, `scan/AVRTargetTester`, the three
+      `http/Series08*Parser`, `log/FeedbackReporter` and `log/SDLogger`. try-with-resources is the
+      convention now (see CLAUDE.md); `http/HTTPSupport` is the reference. Worth converting in
+      passing rather than as its own sweep — `log/FeedbackReporter` and `log/SDLogger` are due for
+      the FileProvider work anyway, so they come for free there.
 - [ ] `misc/add-copyright.sh` still uses the pre-Gradle path (`../src/**/*.java` instead of
       `app/src/main/...`), so it currently matches nothing.
 - [ ] `misc/createicons.sh` looks obsolete and should probably just be deleted: it writes 46 plain

--- a/TODO.md
+++ b/TODO.md
@@ -30,9 +30,8 @@ blocks the current build, which is green.
 
 - [ ] **Test coverage is two files.** `http/HTTPSupportTest` and `http/AVRXMLInfoParserTest` (added
       with the Apache removal) set up `src/test` and the JUnit dependency; everything else is still
-      uncovered. Highest-value next
-      test, because it covers a failure mode the
-      compiler cannot see: `models/ModelConfigurator` resolves the 60 receiver classes **by
+      uncovered. The highest-value test to add next is one for `models/ModelConfigurator`, because it
+      covers a failure mode the compiler cannot see: it resolves the 60 receiver classes **by
       reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
       entry in `res/values/lists.xml` drift and there is no build error — the app silently falls
       back to `AVRGeneric` and the user just misses features. A JVM unit test that runs all 60
@@ -45,7 +44,7 @@ blocks the current build, which is green.
       not namespace-aware by default — on a JVM the parser silently collects nothing. Android's
       Expat-based SAX fills `localName` regardless, which is the only reason the scraping path works.
       Falling back to `qName` when `localName` is empty would make the parser portable and testable.
-      `core/RenameService.java:107` has the same pattern and would need the same fix; the
+      `core/RenameService.java:109` has the same pattern and would need the same fix; the
       `Series08*Parser` classes are unaffected, they read with `BufferedReader` and regexes.
 - [ ] **`NetDisplay.doHTTPMove()` and `doHTTPSeries08Move()` are unreachable.**
       `AbstractModel:135` returns `DisplayMoveMode.Classic` and not one of the 60 model classes

--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,30 @@ blocks the current build, which is green.
       Falling back to `qName` when `localName` is empty would make the parser portable and testable.
       `core/RenameService.java:109` has the same pattern and would need the same fix; the
       `Series08*Parser` classes are unaffected, they read with `BufferedReader` and regexes.
+- [ ] **Nothing in the 2008-series path was verified against hardware.** The Apache removal touched
+      all of it and none of it could be exercised — no such receiver was available. Affected:
+      `http/Series08Reader` (the cookie store it now clears per run, and the `r_option1.asp` →
+      `d_option1.asp` sequence that depends on shared session state), plus
+      `http/Series08ZoneRenameParser` and `http/Series08QuickSelectParser`, whose `OPTION_PATTERN`
+      went from `matches()` with a wrapping `.*` to `find()` in a loop. `http/Series08ParserTest`
+      pins the behaviour that could have broken — notably that the **last** match in a line wins,
+      not the first, which is what the old greedy `.*` did — but those tests were written from the
+      code, not from a real page. One run against a 2008-series receiver settles it: check that
+      input names, zone names and quick-select names all still appear.
+- [ ] Same area, latent NPE: `Series08Reader` has no length check on the response body where
+      `AVRHTTPClient` has one. `Series08InputParser.findLine` returns null when the marker line is
+      missing and the constructor then runs `OPTION_PATTERN.matcher(null)`. An empty or 404 answer
+      triggers it. Pre-existing rather than a regression — but the Apache removal made the asymmetry
+      between the two readers visible, and only one side got the guard.
+- [ ] Same area, cookie lifetime: the store is cleared per Series08 read
+      (`Series08Reader.readSeries08Info`), whereas the old `DefaultHttpClient` was per
+      `AVRHTTPClient` instance, so it also covered the multi-zone path. Exact parity would clear it
+      in the `AVRHTTPClient` constructor. Every receiver tested sends no `Set-Cookie` at all, so
+      this only matters if a 2008-series device turns out to use sessions.
+- [ ] Side effect of the XXE hardening in `http/AVRXMLInfoParser`: on a plain JVM the parser now
+      rejects **any** XML carrying a DOCTYPE, because `disallow-doctype-decl` applies there (on
+      Android it does not — see CLAUDE.md). Receivers never send one, so nothing breaks in the app,
+      but whoever adds the JVM test the item above asks for will trip over it.
 - [ ] **`NetDisplay.doHTTPMove()` and `doHTTPSeries08Move()` are unreachable.**
       `AbstractModel:135` returns `DisplayMoveMode.Classic` and not one of the 60 model classes
       overrides `getDisplayMoveMode()`, so the `switch` in `ScreenMover` always takes the `default`

--- a/TODO.md
+++ b/TODO.md
@@ -28,8 +28,9 @@ blocks the current build, which is green.
 
 ## Structural
 
-- [ ] **Test coverage is one file.** `http/HTTPSupportTest` (added with the Apache removal) set up
-      `src/test` and the JUnit dependency; everything else is still uncovered. Highest-value next
+- [ ] **Test coverage is two files.** `http/HTTPSupportTest` and `http/AVRXMLInfoParserTest` (added
+      with the Apache removal) set up `src/test` and the JUnit dependency; everything else is still
+      uncovered. Highest-value next
       test, because it covers a failure mode the
       compiler cannot see: `models/ModelConfigurator` resolves the 60 receiver classes **by
       reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
@@ -43,8 +44,9 @@ blocks the current build, which is green.
       `endElement` read `localName`, which a standard `SAXParserFactory` leaves empty because it is
       not namespace-aware by default — on a JVM the parser silently collects nothing. Android's
       Expat-based SAX fills `localName` regardless, which is the only reason the scraping path works.
-      Falling back to `qName` when `localName` is empty would make the parser portable and testable;
-      the same pattern is in `Series08*Parser`'s siblings worth checking.
+      Falling back to `qName` when `localName` is empty would make the parser portable and testable.
+      `core/RenameService.java:107` has the same pattern and would need the same fix; the
+      `Series08*Parser` classes are unaffected, they read with `BufferedReader` and regexes.
 - [ ] **`NetDisplay.doHTTPMove()` and `doHTTPSeries08Move()` are unreachable.**
       `AbstractModel:135` returns `DisplayMoveMode.Classic` and not one of the 60 model classes
       overrides `getDisplayMoveMode()`, so the `switch` in `ScreenMover` always takes the `default`

--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,9 @@ blocks the current build, which is green.
 
 ## Structural
 
-- [ ] **There are no tests at all.** Highest-value first test, because it covers a failure mode the
+- [ ] **Test coverage is one file.** `http/HTTPSupportTest` (added with the Apache removal) set up
+      `src/test` and the JUnit dependency; everything else is still uncovered. Highest-value next
+      test, because it covers a failure mode the
       compiler cannot see: `models/ModelConfigurator` resolves the 60 receiver classes **by
       reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
       entry in `res/values/lists.xml` drift and there is no build error — the app silently falls
@@ -37,6 +39,17 @@ blocks the current build, which is green.
       exactly that. Both sides hold 60 entries today, so the test starts green.
 - [ ] After that, `models/` (pure capability logic) and `core/ZoneState.java` (1237 lines) are the
       cheapest places to add coverage.
+- [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and
+      `endElement` read `localName`, which a standard `SAXParserFactory` leaves empty because it is
+      not namespace-aware by default — on a JVM the parser silently collects nothing. Android's
+      Expat-based SAX fills `localName` regardless, which is the only reason the scraping path works.
+      Falling back to `qName` when `localName` is empty would make the parser portable and testable;
+      the same pattern is in `Series08*Parser`'s siblings worth checking.
+- [ ] **`NetDisplay.doHTTPMove()` and `doHTTPSeries08Move()` are unreachable.**
+      `AbstractModel:135` returns `DisplayMoveMode.Classic` and not one of the 60 model classes
+      overrides `getDisplayMoveMode()`, so the `switch` in `ScreenMover` always takes the `default`
+      branch. Both methods (and `DisplayMoveMode`'s other two constants) are dead. Left in place
+      during the Apache removal — decide whether the feature was meant to be wired up or should go.
 - [ ] **The receiver connection lives on a daemon thread owned by `AVRApplication`, not a Service.**
       A design decision from 2010. Under modern background restrictions the process can be reclaimed
       and the connection dies with it. This is the most likely cause of "the app just stops
@@ -53,12 +66,10 @@ blocks the current build, which is green.
 
 ## Time bomb, no fuse length known
 
-- [ ] **Apache HTTP** in `http/AVRHTTPClient`, `http/Series08Reader` and `core/display/NetDisplay`
-      (26 `org.apache.http` imports across the three). Works today: `org.apache.http.legacy.jar` still ships with the android-36
-      platform, and since only cleartext HTTP on the LAN is spoken, the ancient TLS stack does not
-      matter. The risk is purely that Google drops the optional library from some future platform,
-      turning this into unplanned work. It is only GET/POST with form bodies — `HttpURLConnection`
-      would do.
+- [x] **Apache HTTP** in `http/AVRHTTPClient`, `http/Series08Reader` and `core/display/NetDisplay`
+      (26 `org.apache.http` imports across the three). Replaced by `http/HTTPSupport` on
+      `HttpURLConnection`; `useLibrary` and the manifest `<uses-library>` are gone, so the app no
+      longer depends on Google keeping the optional platform library around.
 
 ## Housekeeping
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,6 @@ if (keystorePropertiesFile.canRead()) {
 android {
     namespace "de.pskiwi.avrremote"
     compileSdk 36
-    useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "de.pskiwi.avrremote"
@@ -53,6 +52,10 @@ android {
             }
         }
     }
+}
+
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
 }
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,7 +69,6 @@
             android:exported="false"
             android:label="Options"
             android:theme="@android:style/Theme.Dialog" />
-        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
@@ -17,6 +17,8 @@
 package de.pskiwi.avrremote;
 
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.net.CookieHandler;
+import java.net.CookieManager;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import android.app.Activity;
@@ -96,6 +98,13 @@ public final class AVRApplication extends Application {
 		super.onCreate();
 
 		Logger.setDelegate(ADBLogger.INSTANCE);
+
+		// Der frühere DefaultHttpClient brachte einen Cookie-Store mit, so dass
+		// aufeinander folgende Requests eine Sitzung teilten. HttpURLConnection
+		// tut das nur mit einem gesetzten CookieHandler. Series08Reader ist
+		// darauf angewiesen: dort holt ein r_option1.asp erst den Zustand, den
+		// das folgende d_option1.asp ausliest.
+		CookieHandler.setDefault(new CookieManager());
 
 		final Handler handler = new Handler();
 		final UncaughtExceptionHandler defaultUncaughtExceptionHandler = Thread

--- a/app/src/main/java/de/pskiwi/avrremote/core/display/NetDisplay.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/display/NetDisplay.java
@@ -20,22 +20,14 @@ package de.pskiwi.avrremote.core.display;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicNameValuePair;
 
 import android.app.Activity;
 import android.app.SearchManager;
@@ -55,7 +47,7 @@ import de.pskiwi.avrremote.core.Zone;
 import de.pskiwi.avrremote.core.ZoneState;
 import de.pskiwi.avrremote.core.ZoneState.InputSelect;
 import de.pskiwi.avrremote.core.display.DisplayManager.DisplayType;
-import de.pskiwi.avrremote.http.AVRHTTPClient;
+import de.pskiwi.avrremote.http.HTTPSupport;
 import de.pskiwi.avrremote.log.Logger;
 import de.pskiwi.avrremote.models.ModelConfigurator;
 
@@ -174,26 +166,25 @@ public final class NetDisplay implements IAVRState, IDisplay {
 
 	private final static class CommandBuilder {
 		public void add(String cmd, String param) {
-			formparams
-					.add(new BasicNameValuePair("cmd" + nr, cmd + "/" + param));
+			formparams.put("cmd" + nr, cmd + "/" + param);
 			nr++;
 		}
 
-		public List<NameValuePair> getFormParams() {
+		public Map<String, String> getFormParams() {
 			return formparams;
 		}
 
 		@Override
 		public String toString() {
 			final StringBuilder ret = new StringBuilder("HTTPCommand ");
-			for (NameValuePair nvp : formparams) {
-				ret.append(nvp.getName() + "=" + nvp.getValue() + "&");
+			for (Map.Entry<String, String> nvp : formparams.entrySet()) {
+				ret.append(nvp.getKey() + "=" + nvp.getValue() + "&");
 			}
 			return ret.toString();
 		}
 
 		private int nr = 0;
-		private final List<NameValuePair> formparams = new ArrayList<NameValuePair>();
+		private final Map<String, String> formparams = new LinkedHashMap<String, String>();
 	}
 
 	private final class ScreenMover implements IScreenListener {
@@ -242,20 +233,10 @@ public final class NetDisplay implements IAVRState, IDisplay {
 			});
 		}
 
-		private void doGet(final String toget) throws IOException,
-				ClientProtocolException {
+		private void doGet(final String toget) throws IOException {
 			final String baseURL = modelConfigurator.getConnectionConfig()
 					.getBaseURL();
-			final String url = baseURL + toget;
-			Logger.debug("doGet: [" + url + "] ...");
-			final HttpGet getRequest = new HttpGet(url);
-			final HttpResponse response = httpclient.execute(getRequest);
-			final HttpEntity entity = response.getEntity();
-			if (entity != null) {
-				entity.consumeContent();
-			}
-			Logger.debug("doGet [" + url + "] code:"
-					+ response.getStatusLine().getStatusCode());
+			HTTPSupport.get(baseURL + toget);
 		}
 
 		private void doHTTPMove() {
@@ -281,20 +262,9 @@ public final class NetDisplay implements IAVRState, IDisplay {
 							cb.add("osThreadSleep", "50");
 						}
 						cb.add("PutNetAudioCommand", "CurRight");
-						UrlEncodedFormEntity form = new UrlEncodedFormEntity(cb
-								.getFormParams(), "UTF-8");
 						Logger.info("do HTTP POST Move : " + cb.toString());
-						HttpPost httppost = new HttpPost(baseURL
-								+ "NetAudio/index.put.asp");
-						httppost.setEntity(form);
-
-						HttpResponse response = httpclient.execute(httppost);
-						Logger.debug("doHTTPMove Code:"
-								+ response.getStatusLine().getStatusCode());
-						final HttpEntity entity = response.getEntity();
-						if (entity != null) {
-							entity.consumeContent();
-						}
+						HTTPSupport.postForm(baseURL
+								+ "NetAudio/index.put.asp", cb.getFormParams());
 					} catch (Exception x) {
 						Logger.error("HTTP Move failed", x);
 					}
@@ -685,7 +655,6 @@ public final class NetDisplay implements IAVRState, IDisplay {
 	 */
 	public NetDisplay(ISender sender, ModelConfigurator modelConfigurator,
 			DisplayType type) {
-		AVRHTTPClient.configureHTTPClient(httpclient);
 		this.sender = sender;
 		this.modelConfigurator = modelConfigurator;
 		switch (type) {
@@ -1177,7 +1146,6 @@ public final class NetDisplay implements IAVRState, IDisplay {
 
 	private static final int MAX_MOVE_TIME = 20000;
 
-	private final DefaultHttpClient httpclient = new DefaultHttpClient();
 	private final Executor moveExecutor = Executors.newSingleThreadExecutor();
 
 }

--- a/app/src/main/java/de/pskiwi/avrremote/http/AVRHTTPClient.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/AVRHTTPClient.java
@@ -177,6 +177,12 @@ public final class AVRHTTPClient {
 		final byte[] content = HTTPSupport.get(baseURL
 				+ "goform/formMainZone_MainZoneXml.xml?ZoneName=ZONE"
 				+ (z.getZoneNumber() + 1));
+		// Die Längenprüfung tritt an die Stelle des früheren "entity != null":
+		// AVRXMLInfoParser.parse wirft bei leerem Body. Sie ist nicht exakt
+		// gleichbedeutend - Apache lieferte auch für 200 ohne Inhalt eine
+		// Entity, so dass eine leere Antwort die gesamte XML-Abfrage aller
+		// Zonen per Exception verwarf. Jetzt gilt die Zone als undefiniert und
+		// die bereits gelesenen Zonen bleiben erhalten.
 		AVRXMLInfo info = new AVRXMLInfo();
 		if (content.length > 0) {
 			info = new AVRXMLInfoParser().parse(new ByteArrayInputStream(

--- a/app/src/main/java/de/pskiwi/avrremote/http/AVRHTTPClient.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/AVRHTTPClient.java
@@ -16,22 +16,10 @@
  */
 package de.pskiwi.avrremote.http;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import de.pskiwi.avrremote.core.Zone;
 import de.pskiwi.avrremote.log.Logger;
@@ -41,29 +29,6 @@ public final class AVRHTTPClient {
 
 	public AVRHTTPClient(ModelConfigurator cfg) {
 		this.baseURL = cfg.getConnectionConfig().getBaseURL();
-
-		configureHTTPClient(httpclient);
-	}
-
-	// Workaround für OOM
-	// http://stackoverflow.com/questions/5358014/android-httpclient-oom-on-4g-lte-htc-thunderbolt
-	public static void configureHTTPClient(DefaultHttpClient httpclient) {
-		// Set the timeout in milliseconds until a connection is established.
-		int timeoutConnection = 5000;
-
-		// Set the default socket timeout (SO_TIMEOUT)
-		// in milliseconds which is the timeout for waiting for data.
-		int timeoutSocket = 4000;
-
-		// set timeout parameters for HttpClient
-		HttpParams httpParameters = new BasicHttpParams();
-		HttpConnectionParams.setConnectionTimeout(httpParameters,
-				timeoutConnection);
-		HttpConnectionParams.setSoTimeout(httpParameters, timeoutSocket);
-		HttpConnectionParams.setSocketBufferSize(httpParameters, 8192);// setting
-																		// setSocketBufferSize
-
-		httpclient.setParams(httpParameters);
 	}
 
 	public void doBackgroundReset(final Runnable runnable) {
@@ -96,16 +61,10 @@ public final class AVRHTTPClient {
 	}
 
 	private void postValue(String value) throws Exception {
-		List<NameValuePair> formparams = new ArrayList<NameValuePair>();
-		formparams.add(new BasicNameValuePair("cmd0", value));
-		// formparams.add(new BasicNameValuePair("param2", "value2"));
-		UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams,
-				"UTF-8");
-		HttpPost httppost = new HttpPost(baseURL + "MainZone/index.put.asp");
-		httppost.setEntity(form);
-
-		HttpResponse response = httpclient.execute(httppost);
-		System.out.println("Code:" + response.getStatusLine().getStatusCode());
+		Map<String, String> formparams = new LinkedHashMap<String, String>();
+		formparams.put("cmd0", value);
+		// formparams.put("param2", "value2");
+		HTTPSupport.postForm(baseURL + "MainZone/index.put.asp", formparams);
 	}
 
 	public enum SearchInputType {
@@ -180,23 +139,13 @@ public final class AVRHTTPClient {
 			String toSearch) throws Exception {
 		Logger.info("doSearch input:" + inputType + " type:" + type + " text["
 				+ toSearch + "]");
-		List<NameValuePair> formparams = new ArrayList<NameValuePair>();
-		formparams.add(new BasicNameValuePair("cmd0", "PutNetFuncSearch"
-				+ inputType.getKeyword() + "/" + toSearch));
+		Map<String, String> formparams = new LinkedHashMap<String, String>();
+		formparams.put("cmd0", "PutNetFuncSearch" + inputType.getKeyword() + "/"
+				+ toSearch);
 		if (type != SearchType.None) {
-			formparams.add(new BasicNameValuePair("Key", type.getToken()));
+			formparams.put("Key", type.getToken());
 		}
-		UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams,
-				"UTF-8");
-		HttpPost httppost = new HttpPost(baseURL + "NetAudio/index.put.asp");
-		httppost.setEntity(form);
-
-		HttpResponse response = httpclient.execute(httppost);
-		final HttpEntity entity = response.getEntity();
-		if (entity != null) {
-			entity.consumeContent();
-		}
-		System.out.println("Code:" + response.getStatusLine().getStatusCode());
+		HTTPSupport.postForm(baseURL + "NetAudio/index.put.asp", formparams);
 	}
 
 	// Zonen-Namen stehen in den verschiedenen Zonen-Infos (Merge)
@@ -204,7 +153,7 @@ public final class AVRHTTPClient {
 			throws Exception {
 		Logger.info("read XML state");
 		if (configurator.getModel().useSeries08Parser()) {
-			return new Series08Reader(httpclient, baseURL).readSeries08Info();
+			return new Series08Reader(baseURL).readSeries08Info();
 		} else {
 			final AVRXMLInfo ret = new AVRXMLInfo();
 			for (Zone z : Zone.values()) {
@@ -225,14 +174,13 @@ public final class AVRHTTPClient {
 
 	// Status für Zone lesen
 	private AVRXMLInfo readState(Zone z) throws Exception {
-		final HttpGet httpGet = new HttpGet(baseURL
+		final byte[] content = HTTPSupport.get(baseURL
 				+ "goform/formMainZone_MainZoneXml.xml?ZoneName=ZONE"
 				+ (z.getZoneNumber() + 1));
-		final HttpResponse response = httpclient.execute(httpGet);
-		final HttpEntity entity = response.getEntity();
 		AVRXMLInfo info = new AVRXMLInfo();
-		if (entity != null) {
-			info = new AVRXMLInfoParser().parse(entity.getContent());
+		if (content.length > 0) {
+			info = new AVRXMLInfoParser().parse(new ByteArrayInputStream(
+					content));
 		}
 
 		readQuickInfo(z, info);
@@ -244,16 +192,13 @@ public final class AVRHTTPClient {
 		}
 	}
 
-	private void readQuickInfo(Zone z, AVRXMLInfo info) throws IOException,
-			ClientProtocolException {
-		final HttpGet quickHttpGet = new HttpGet(baseURL
+	private void readQuickInfo(Zone z, AVRXMLInfo info) throws IOException {
+		final byte[] content = HTTPSupport.get(baseURL
 				+ "goform/formMainZone_QuickSelectXml.xml?ZoneName=ZONE"
 				+ (z.getZoneNumber() + 1));
-		final HttpResponse quickResponse = httpclient.execute(quickHttpGet);
-		final HttpEntity quickEntity = quickResponse.getEntity();
-		if (quickEntity != null) {
+		if (content.length > 0) {
 			final AVRXMLInfo quickInfo = new AVRXMLInfoParser()
-					.parse(quickEntity.getContent());
+					.parse(new ByteArrayInputStream(content));
 			if (quickInfo.isDefined()) {
 				info.mergeQuickSelect(z, quickInfo);
 			}
@@ -261,5 +206,4 @@ public final class AVRHTTPClient {
 	}
 
 	private final String baseURL;
-	private final DefaultHttpClient httpclient = new DefaultHttpClient();
 }

--- a/app/src/main/java/de/pskiwi/avrremote/http/AVRHTTPClient.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/AVRHTTPClient.java
@@ -65,6 +65,8 @@ public final class AVRHTTPClient {
 		formparams.put("cmd0", value);
 		// formparams.put("param2", "value2");
 		HTTPSupport.postForm(baseURL + "MainZone/index.put.asp", formparams);
+		// Statuscode loggt HTTPSupport, hier interessiert das Kommando
+		Logger.info("postValue [" + value + "] gesendet");
 	}
 
 	public enum SearchInputType {
@@ -146,6 +148,8 @@ public final class AVRHTTPClient {
 			formparams.put("Key", type.getToken());
 		}
 		HTTPSupport.postForm(baseURL + "NetAudio/index.put.asp", formparams);
+		// Statuscode loggt HTTPSupport, hier interessiert der Abschluss
+		Logger.info("doSearch [" + toSearch + "] gesendet");
 	}
 
 	// Zonen-Namen stehen in den verschiedenen Zonen-Infos (Merge)

--- a/app/src/main/java/de/pskiwi/avrremote/http/AVRXMLInfoParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/AVRXMLInfoParser.java
@@ -73,19 +73,35 @@ public final class AVRXMLInfoParser extends DefaultHandler {
 		// Welche Sperre greift, hängt von der Plattform ab - auf einem Pixel 8
 		// durchprobiert: Androids SAXParserFactoryImpl unterstützt nur die
 		// beiden external-*-Features und wirft bei den anderen beiden
-		// SAXNotRecognizedException. Deshalb einzeln absichern statt in einem
-		// Block: sonst verhindert die erste nicht unterstützte Sperre alle
-		// folgenden - und das war getestet der Fall.
+		// SAXNotRecognizedException. Deshalb jede einzeln absichern: in einem
+		// gemeinsamen Block würde die erste nicht unterstützte alle folgenden
+		// überspringen.
 		final SAXParserFactory factory = SAXParserFactory.newInstance();
+
+		// Die beiden tragenden Sperren, jede für sich. Lässt sich eine nicht
+		// setzen, wird nicht geparst - ein ungeschützter Parser auf
+		// unauthentifiziertem LAN-XML ist schlimmer als eine fehlende
+		// Statusanzeige. Der Aufrufer fängt das ab (StatusAreaManager), die
+		// Abfrage entfällt dann laut statt still und unsicher.
+		// Die setFeature-Aufrufe stehen bewusst direkt hier und nicht in einer
+		// Hilfsmethode: die statische Analyse erkennt die Absicherung sonst
+		// womöglich nicht mehr.
 		try {
-			// auf Android der eigentliche Schutz
 			factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
-			factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
 		} catch (Exception x) {
-			Logger.error("externe Entities nicht abschaltbar", x);
+			throw new RuntimeException("nicht abschaltbar: "
+					+ EXTERNAL_GENERAL_ENTITIES, x);
 		}
 		try {
-			// auf der JVM zusätzlich, auf Android nicht vorhanden
+			factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+		} catch (Exception x) {
+			throw new RuntimeException("nicht abschaltbar: "
+					+ EXTERNAL_PARAMETER_ENTITIES, x);
+		}
+
+		// Zusätzlich auf der JVM; auf Android nicht vorhanden und dort
+		// entbehrlich, weil die beiden oben bereits greifen.
+		try {
 			factory.setFeature(DISALLOW_DOCTYPE, true);
 		} catch (Exception x) {
 			Logger.debug("XML-Feature nicht unterstützt: " + DISALLOW_DOCTYPE);

--- a/app/src/main/java/de/pskiwi/avrremote/http/AVRXMLInfoParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/AVRXMLInfoParser.java
@@ -66,17 +66,36 @@ public final class AVRXMLInfoParser extends DefaultHandler {
 
 	public AVRXMLInfo parse(InputStream in) {
 
+		// Das XML kommt unauthentifiziert per Klartext-HTTP aus dem LAN. Ohne
+		// die folgenden Sperren könnte ein vorgetäuschter Receiver über externe
+		// Entities lokale Dateien auslesen (XXE).
+		//
+		// Welche Sperre greift, hängt von der Plattform ab - auf einem Pixel 8
+		// durchprobiert: Androids SAXParserFactoryImpl unterstützt nur die
+		// beiden external-*-Features und wirft bei den anderen beiden
+		// SAXNotRecognizedException. Deshalb einzeln absichern statt in einem
+		// Block: sonst verhindert die erste nicht unterstützte Sperre alle
+		// folgenden - und das war getestet der Fall.
 		final SAXParserFactory factory = SAXParserFactory.newInstance();
 		try {
-			// Das XML kommt unauthentifiziert per Klartext-HTTP aus dem LAN.
-			// Ohne dies könnte ein vorgetäuschter Receiver über externe
-			// Entities lokale Dateien auslesen (XXE).
-			// Achtung: "disallow-doctype-decl" wäre die naheliegende Sperre,
-			// Androids SAXParserFactoryImpl kennt sie aber nicht und wirft
-			// SAXNotRecognizedException - auf einem Pixel 8 nachgemessen.
-			// Diese beiden Features werden dort unterstützt.
+			// auf Android der eigentliche Schutz
 			factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
 			factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+		} catch (Exception x) {
+			Logger.error("externe Entities nicht abschaltbar", x);
+		}
+		try {
+			// auf der JVM zusätzlich, auf Android nicht vorhanden
+			factory.setFeature(DISALLOW_DOCTYPE, true);
+		} catch (Exception x) {
+			Logger.debug("XML-Feature nicht unterstützt: " + DISALLOW_DOCTYPE);
+		}
+		try {
+			factory.setFeature(LOAD_EXTERNAL_DTD, false);
+		} catch (Exception x) {
+			Logger.debug("XML-Feature nicht unterstützt: " + LOAD_EXTERNAL_DTD);
+		}
+		try {
 			SAXParser parser = factory.newSAXParser();
 			parser.parse(in, this);
 		} catch (Exception e) {
@@ -92,6 +111,8 @@ public final class AVRXMLInfoParser extends DefaultHandler {
 
 	private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
 	private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+	private static final String DISALLOW_DOCTYPE = "http://apache.org/xml/features/disallow-doctype-decl";
+	private static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 	private static final String VALUE_TAG = "value";
 	private static final String ROOT_TAG = "item";
 }

--- a/app/src/main/java/de/pskiwi/avrremote/http/AVRXMLInfoParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/AVRXMLInfoParser.java
@@ -68,6 +68,15 @@ public final class AVRXMLInfoParser extends DefaultHandler {
 
 		final SAXParserFactory factory = SAXParserFactory.newInstance();
 		try {
+			// Das XML kommt unauthentifiziert per Klartext-HTTP aus dem LAN.
+			// Ohne dies könnte ein vorgetäuschter Receiver über externe
+			// Entities lokale Dateien auslesen (XXE).
+			// Achtung: "disallow-doctype-decl" wäre die naheliegende Sperre,
+			// Androids SAXParserFactoryImpl kennt sie aber nicht und wirft
+			// SAXNotRecognizedException - auf einem Pixel 8 nachgemessen.
+			// Diese beiden Features werden dort unterstützt.
+			factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+			factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
 			SAXParser parser = factory.newSAXParser();
 			parser.parse(in, this);
 		} catch (Exception e) {
@@ -81,6 +90,8 @@ public final class AVRXMLInfoParser extends DefaultHandler {
 	private String value;
 	private final AVRXMLInfo info = new AVRXMLInfo();
 
+	private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+	private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
 	private static final String VALUE_TAG = "value";
 	private static final String ROOT_TAG = "item";
 }

--- a/app/src/main/java/de/pskiwi/avrremote/http/HTTPSupport.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/HTTPSupport.java
@@ -46,6 +46,10 @@ public final class HTTPSupport {
 	}
 
 	private static byte[] execute(String url, byte[] body) throws IOException {
+		final String method = body != null ? "POST" : "GET";
+		// vor dem Request loggen: bei Timeout oder Exception taucht die URL
+		// sonst nirgends im Log auf, das FeedbackReporter verschickt
+		Logger.debug(method + " [" + url + "] ...");
 		final HttpURLConnection connection = (HttpURLConnection) new URL(url)
 				.openConnection();
 		try {
@@ -59,7 +63,10 @@ public final class HTTPSupport {
 				connection.setDoOutput(true);
 				connection.setRequestProperty("Content-Type", FORM_CONTENT_TYPE);
 				// ohne feste Länge wird chunked gesendet, das versteht der
-				// Receiver nicht
+				// Receiver nicht. Nebeneffekt: mit gestreamtem Body kann
+				// getResponseCode() den Request nicht wiederholen und wirft bei
+				// 3xx/401 eine HttpRetryException. Apache lieferte den Status
+				// einfach zurück. Bisher an keinem Receiver beobachtet.
 				connection.setFixedLengthStreamingMode(body.length);
 				final OutputStream out = connection.getOutputStream();
 				try {
@@ -71,8 +78,8 @@ public final class HTTPSupport {
 			final int code = connection.getResponseCode();
 			final byte[] content = readAll(code >= HttpURLConnection.HTTP_BAD_REQUEST ? connection
 					.getErrorStream() : connection.getInputStream());
-			Logger.debug((body != null ? "POST" : "GET") + " [" + url
-					+ "] code:" + code + " bytes:" + content.length);
+			Logger.debug(method + " [" + url + "] code:" + code + " bytes:"
+					+ content.length);
 			return content;
 		} finally {
 			connection.disconnect();

--- a/app/src/main/java/de/pskiwi/avrremote/http/HTTPSupport.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/HTTPSupport.java
@@ -68,11 +68,8 @@ public final class HTTPSupport {
 				// 3xx/401 eine HttpRetryException. Apache lieferte den Status
 				// einfach zurück. Bisher an keinem Receiver beobachtet.
 				connection.setFixedLengthStreamingMode(body.length);
-				final OutputStream out = connection.getOutputStream();
-				try {
+				try (OutputStream out = connection.getOutputStream()) {
 					out.write(body);
-				} finally {
-					out.close();
 				}
 			}
 			final int code = connection.getResponseCode();
@@ -90,16 +87,14 @@ public final class HTTPSupport {
 		if (in == null) {
 			return new byte[0];
 		}
-		try {
+		try (InputStream stream = in) {
 			final ByteArrayOutputStream ret = new ByteArrayOutputStream();
 			final byte[] buffer = new byte[8192];
 			int read;
-			while ((read = in.read(buffer)) != -1) {
+			while ((read = stream.read(buffer)) != -1) {
 				ret.write(buffer, 0, read);
 			}
 			return ret.toByteArray();
-		} finally {
-			in.close();
 		}
 	}
 

--- a/app/src/main/java/de/pskiwi/avrremote/http/HTTPSupport.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/HTTPSupport.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Map;
+
+import de.pskiwi.avrremote.log.Logger;
+
+/**
+ * GET und POST gegen den Receiver. Ersetzt den früheren Apache-HttpClient, der
+ * nur noch als optionale Plattform-Bibliothek existierte. Mehr als diese beiden
+ * Operationen hat die App nie benutzt.
+ */
+public final class HTTPSupport {
+
+	public static byte[] get(String url) throws IOException {
+		return execute(url, null);
+	}
+
+	/** POST mit application/x-www-form-urlencoded-Body. */
+	public static byte[] postForm(String url, Map<String, String> formParams)
+			throws IOException {
+		return execute(url, encodeForm(formParams).getBytes("US-ASCII"));
+	}
+
+	private static byte[] execute(String url, byte[] body) throws IOException {
+		final HttpURLConnection connection = (HttpURLConnection) new URL(url)
+				.openConnection();
+		try {
+			connection.setConnectTimeout(CONNECT_TIMEOUT);
+			connection.setReadTimeout(READ_TIMEOUT);
+			// HttpURLConnection fragt von sich aus gzip an, der Apache-Client
+			// tat das nie. Für die betagten Receiver-Webserver abschalten.
+			connection.setRequestProperty("Accept-Encoding", "identity");
+			if (body != null) {
+				connection.setRequestMethod("POST");
+				connection.setDoOutput(true);
+				connection.setRequestProperty("Content-Type", FORM_CONTENT_TYPE);
+				// ohne feste Länge wird chunked gesendet, das versteht der
+				// Receiver nicht
+				connection.setFixedLengthStreamingMode(body.length);
+				final OutputStream out = connection.getOutputStream();
+				try {
+					out.write(body);
+				} finally {
+					out.close();
+				}
+			}
+			final int code = connection.getResponseCode();
+			final byte[] content = readAll(code >= HttpURLConnection.HTTP_BAD_REQUEST ? connection
+					.getErrorStream() : connection.getInputStream());
+			Logger.debug((body != null ? "POST" : "GET") + " [" + url
+					+ "] code:" + code + " bytes:" + content.length);
+			return content;
+		} finally {
+			connection.disconnect();
+		}
+	}
+
+	private static byte[] readAll(InputStream in) throws IOException {
+		if (in == null) {
+			return new byte[0];
+		}
+		try {
+			final ByteArrayOutputStream ret = new ByteArrayOutputStream();
+			final byte[] buffer = new byte[8192];
+			int read;
+			while ((read = in.read(buffer)) != -1) {
+				ret.write(buffer, 0, read);
+			}
+			return ret.toByteArray();
+		} finally {
+			in.close();
+		}
+	}
+
+	private static String encodeForm(Map<String, String> formParams)
+			throws UnsupportedEncodingException {
+		final StringBuilder ret = new StringBuilder();
+		for (Map.Entry<String, String> e : formParams.entrySet()) {
+			if (ret.length() > 0) {
+				ret.append('&');
+			}
+			ret.append(URLEncoder.encode(e.getKey(), "UTF-8"));
+			ret.append('=');
+			ret.append(URLEncoder.encode(e.getValue(), "UTF-8"));
+		}
+		return ret.toString();
+	}
+
+	private HTTPSupport() {
+	}
+
+	private static final String FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+	private static final int CONNECT_TIMEOUT = 5000;
+	private static final int READ_TIMEOUT = 4000;
+}

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08QuickSelectParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08QuickSelectParser.java
@@ -52,7 +52,7 @@ public final class Series08QuickSelectParser {
 		Logger.debug("Series08QuickSelectRename [" + line + "]");
 		final Matcher matcher = OPTION_PATTERN.matcher(line);
 		String value = null;
-		// group(2)->selected
+		// group(2) ist der Anzeigename
 		String display = null;
 		// Der letzte Treffer gewinnt: das frühere matches() mit führendem
 		// gierigem ".*" wählte ebenfalls das rechteste Vorkommen. find() in

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08QuickSelectParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08QuickSelectParser.java
@@ -50,17 +50,23 @@ public final class Series08QuickSelectParser {
 
 	private Input parseLine(String line) {
 		Logger.debug("Series08QuickSelectRename [" + line + "]");
-		Matcher matcher = OPTION_PATTERN.matcher(line);
-		if (matcher.matches()) {
-			String value = matcher.group(1).trim();
-			// group(2)->selected
-			String display = matcher.group(2).trim();
-			Logger.debug("Series08QuickSelectRename [" + value + "]->["
-					+ display + "]");
-			return new Input(value, display, true);
-		} else {
+		final Matcher matcher = OPTION_PATTERN.matcher(line);
+		String value = null;
+		// group(2)->selected
+		String display = null;
+		// Der letzte Treffer gewinnt: das frühere matches() mit führendem
+		// gierigem ".*" wählte ebenfalls das rechteste Vorkommen. find() in
+		// der Schleife tut dasselbe, ohne die mehrdeutige Rückverfolgung.
+		while (matcher.find()) {
+			value = matcher.group(1).trim();
+			display = matcher.group(2).trim();
+		}
+		if (value == null) {
 			return null;
 		}
+		Logger.debug("Series08QuickSelectRename [" + value + "]->[" + display
+				+ "]");
+		return new Input(value, display, true);
 	}
 
 	public void parse() throws IOException {
@@ -104,6 +110,6 @@ public final class Series08QuickSelectParser {
 
 	// <option value='TUNER'>TUNER </option>
 	private final Pattern OPTION_PATTERN = Pattern
-			.compile(".*name='([^']+)' value=\"([^\"]+)\".*");
+			.compile("name='([^']+)' value=\"([^\"]+)\"");
 	private final static String START_MARKER = "name='textQuickSelectNameSelect$'";
 }

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08Reader.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08Reader.java
@@ -16,22 +16,16 @@
  */
 package de.pskiwi.avrremote.http;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
 
 import de.pskiwi.avrremote.http.AVRXMLInfo.Input;
 import de.pskiwi.avrremote.log.Logger;
 
 public final class Series08Reader {
 
-	public Series08Reader(DefaultHttpClient httpclient, String baseURL) {
-		this.httpclient = httpclient;
+	public Series08Reader(String baseURL) {
 		this.baseURL = baseURL;
 	}
 
@@ -47,29 +41,16 @@ public final class Series08Reader {
 
 	}
 
-	private void doGet(final String toget) throws IOException,
-			ClientProtocolException {
-		final String url = baseURL + toget;
-		Logger.debug("doGet: [" + url + "] ...");
-		final HttpGet getRequest = new HttpGet(url);
-		final HttpResponse response = httpclient.execute(getRequest);
-		final HttpEntity entity = response.getEntity();
-		if (entity != null) {
-			entity.consumeContent();
-		}
-		Logger.debug("doGet [" + url + "] code:"
-				+ response.getStatusLine().getStatusCode());
+	private void doGet(final String toget) throws IOException {
+		HTTPSupport.get(baseURL + toget);
 	}
 
-	private void readSeries08Renames(final AVRXMLInfo info) throws IOException,
-			ClientProtocolException {
+	private void readSeries08Renames(final AVRXMLInfo info) throws IOException {
 		Logger.debug("readSeries08Renames ...");
-		final HttpGet httpGet = new HttpGet(baseURL
+		final byte[] content = HTTPSupport.get(baseURL
 				+ "SETUP/01_SOURCESELECT/d_inputsetup.asp");
-		final HttpResponse response = httpclient.execute(httpGet);
-		final HttpEntity entity = response.getEntity();
 		final Series08InputParser p = new Series08InputParser(
-				entity.getContent());
+				new ByteArrayInputStream(content));
 		final List<Input> inputs = p.get();
 		if (!inputs.isEmpty()) {
 			Logger.debug("Series08 inputs#" + inputs.size());
@@ -80,50 +61,42 @@ public final class Series08Reader {
 		} else {
 			Logger.debug("Series08 no info");
 		}
-		Logger.debug("readSeries08Renames "
-				+ response.getStatusLine().getStatusCode());
+		Logger.debug("readSeries08Renames done");
 	}
 
 	private void readSeries08ZoneNames(final AVRXMLInfo info)
-			throws IOException, ClientProtocolException {
+			throws IOException {
 		Logger.debug("readSeries08ZoneNames ...");
-		final HttpGet httpGet = new HttpGet(baseURL
+		final byte[] content = HTTPSupport.get(baseURL
 				+ "ZONERENAME/d_zonerename.asp");
-		final HttpResponse response = httpclient.execute(httpGet);
-		final HttpEntity entity = response.getEntity();
 
 		final Series08ZoneRenameParser p = new Series08ZoneRenameParser(
-				entity.getContent());
+				new ByteArrayInputStream(content));
 		p.parse();
 		for (String s : p.getZoneNames()) {
 			info.add(AVRXMLInfo.RENAME_ZONE, s);
 		}
-		Logger.debug("readSeries08ZoneNames "
-				+ response.getStatusLine().getStatusCode());
+		Logger.debug("readSeries08ZoneNames done");
 	}
 
 	private void readSeries08QuickSelect(final AVRXMLInfo info)
-			throws IOException, ClientProtocolException {
+			throws IOException {
 		Logger.debug("readSeries08QuickSelect init...");
 		// sonst sind nachher die Daten nicht enthalten
 		doGet("SETUP/04_MANUALSETUP/09_OPTION1/r_option1.asp");
 		Logger.debug("readSeries08QuickSelect ...");
-		final HttpGet httpGet = new HttpGet(baseURL
+		final byte[] content = HTTPSupport.get(baseURL
 				+ "SETUP/04_MANUALSETUP/09_OPTION1/d_option1.asp");
-		final HttpResponse response = httpclient.execute(httpGet);
-		final HttpEntity entity = response.getEntity();
 		final Series08QuickSelectParser p = new Series08QuickSelectParser(
-				entity.getContent());
+				new ByteArrayInputStream(content));
 		p.parse();
 		for (String s : p.get()) {
 			final String key = AVRXMLInfo.QUICK_SELECT_NAME + "0";
 			Logger.info("[" + key + "]->[" + s + "]");
 			info.add(key, s);
 		}
-		Logger.debug("readSeries08QuickSelect "
-				+ response.getStatusLine().getStatusCode());
+		Logger.debug("readSeries08QuickSelect done");
 	}
 
-	private final DefaultHttpClient httpclient;
 	private final String baseURL;
 }

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08Reader.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08Reader.java
@@ -18,6 +18,8 @@ package de.pskiwi.avrremote.http;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.CookieHandler;
+import java.net.CookieManager;
 import java.util.List;
 
 import de.pskiwi.avrremote.http.AVRXMLInfo.Input;
@@ -30,6 +32,16 @@ public final class Series08Reader {
 	}
 
 	public AVRXMLInfo readSeries08Info() throws Exception {
+
+		// Der frühere DefaultHttpClient wurde je Lesevorgang neu angelegt,
+		// seine Cookies galten also nur für diesen einen Durchlauf. Der
+		// prozessweite CookieHandler aus AVRApplication lebt dagegen bis zum
+		// Prozessende - vor jedem Durchlauf leeren, sonst würde eine veraltete
+		// Sitzungs-ID weiter mitgeschickt.
+		final CookieHandler cookies = CookieHandler.getDefault();
+		if (cookies instanceof CookieManager) {
+			((CookieManager) cookies).getCookieStore().removeAll();
+		}
 
 		final AVRXMLInfo info = new AVRXMLInfo();
 

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08ZoneRenameParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08ZoneRenameParser.java
@@ -42,7 +42,12 @@ public final class Series08ZoneRenameParser {
 		try {
 			String line;
 			while ((line = r.readLine()) != null) {
-				Logger.debug(line);
+				// Hier stand ein System.out.println(line). Nicht nach
+				// Logger.debug übernommen: das schreibt in den
+				// RoundRobinLogger mit 25 Einträgen, den der FeedbackReporter
+				// bei Abstürzen verschickt - eine HTML-Seite zeilenweise
+				// hineinzukippen macht ihn wertlos. Jeder Treffer wird unten
+				// ohnehin geloggt.
 				final Matcher matcher = OPTION_PATTERN.matcher(line);
 				String key = null;
 				String value = null;

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08ZoneRenameParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08ZoneRenameParser.java
@@ -42,15 +42,22 @@ public final class Series08ZoneRenameParser {
 		try {
 			String line;
 			while ((line = r.readLine()) != null) {
-				System.out.println(line);
-				Matcher matcher = OPTION_PATTERN.matcher(line);
-				if (matcher.matches()) {
-					String key = matcher.group(1).trim();
-					String value = matcher.group(2).trim();
+				Logger.debug(line);
+				final Matcher matcher = OPTION_PATTERN.matcher(line);
+				String key = null;
+				String value = null;
+				// Der letzte Treffer gewinnt: das frühere matches() mit
+				// führendem gierigem ".*" wählte ebenfalls das rechteste
+				// Vorkommen. find() in der Schleife tut dasselbe, ohne die
+				// mehrdeutige Rückverfolgung.
+				while (matcher.find()) {
+					key = matcher.group(1).trim();
+					value = matcher.group(2).trim();
+				}
+				if (key != null) {
 					map.put(key, value);
 					Logger.info("Series08ZoneRename[" + key + "]->[" + value
 							+ "]");
-
 				}
 			}
 		} finally {
@@ -95,7 +102,7 @@ public final class Series08ZoneRenameParser {
 
 	// name='Main' value="ThisIsZone1     "
 	private final Pattern OPTION_PATTERN = Pattern
-			.compile(".*name='([^']+)' value=\"([^\"]+)\".*");
+			.compile("name='([^']+)' value=\"([^\"]+)\"");
 	private final static String[] ZONE_KEYS = { "Main", "Zone2", "Zone3",
 			"Zone4", "Zone5" };
 	private final static String[] DEFAULT_NAMES = { "Main", "Zone 2", "Zone 3",

--- a/app/src/test/java/de/pskiwi/avrremote/http/AVRXMLInfoParserTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/AVRXMLInfoParserTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.http;
+
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+/**
+ * Hält fest, warum {@code AVRHTTPClient.readState} und
+ * {@code readQuickInfo} den Body auf Länge prüfen, bevor sie parsen: bei leerer
+ * Antwort wirft der Parser. Vor dem Wegfall des Apache-Clients übernahm diese
+ * Rolle die Prüfung {@code entity != null}.
+ */
+public final class AVRXMLInfoParserTest {
+
+	@Test
+	public void parseThrowsOnEmptyBody() {
+		try {
+			new AVRXMLInfoParser().parse(stream(""));
+			fail("leerer Body muss zu einer Exception führen -"
+					+ " sonst ist die Längenprüfung in AVRHTTPClient überflüssig");
+		} catch (RuntimeException expected) {
+			// so gewollt: der Aufrufer darf gar nicht erst hierher kommen
+		}
+	}
+
+	// Eine Gegenprobe mit echtem Receiver-XML ist hier bewusst nicht möglich:
+	// AVRXMLInfoParser wertet in startElement/endElement nur localName aus. Auf
+	// einer normalen JVM ist SAXParserFactory nicht namespace-aware, localName
+	// bleibt leer und der Parser sammelt nichts ein. Auf Android füllt der
+	// Expat-basierte SAX localName trotzdem, deshalb funktioniert der Pfad im
+	// Betrieb. Der Parser lässt sich damit nur auf dem Gerät prüfen.
+
+	private static InputStream stream(String xml) {
+		try {
+			return new ByteArrayInputStream(xml.getBytes("UTF-8"));
+		} catch (Exception x) {
+			throw new RuntimeException(x);
+		}
+	}
+}

--- a/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Prüft die Eigenschaften, in denen sich HttpURLConnection vom früher benutzten
+ * Apache-HttpClient unterscheidet und in denen die Receiver-Webserver (GoAhead,
+ * HTTP/1.0) empfindlich sind: Content-Length statt chunked, kein gzip,
+ * Content-Type und Kodierung des Formular-Bodys.
+ *
+ * Der Testserver ist ein roher ServerSocket, damit die Zusicherungen auf den
+ * tatsächlich gesendeten Bytes sitzen und nicht auf einer geparsten Sicht
+ * darauf. Es wird kein Receiver benötigt.
+ */
+public final class HTTPSupportTest {
+
+	@Before
+	public void startServer() throws IOException {
+		server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+		baseURL = "http://127.0.0.1:" + server.getLocalPort();
+		serverThread = new Thread("test-receiver") {
+			@Override
+			public void run() {
+				serveOneRequest();
+			}
+		};
+		serverThread.start();
+	}
+
+	@After
+	public void stopServer() throws Exception {
+		serverThread.join(5000);
+		server.close();
+		if (failure != null) {
+			throw failure;
+		}
+	}
+
+	@Test
+	public void getReturnsBodyAndKeepsPathAndQuery() throws Exception {
+		responseBody = "<?xml version=\"1.0\"?><item/>";
+
+		final byte[] content = HTTPSupport.get(baseURL
+				+ "/goform/formMainZone_MainZoneXml.xml?ZoneName=ZONE1");
+
+		assertEquals(responseBody, new String(content, "UTF-8"));
+		assertEquals("GET /goform/formMainZone_MainZoneXml.xml?ZoneName=ZONE1"
+				+ " HTTP/1.1", requestLine());
+	}
+
+	/** NetDisplay baut genau eine URL mit doppeltem Slash - die muss so rausgehen. */
+	@Test
+	public void getKeepsDoubleSlashInPath() throws Exception {
+		HTTPSupport.get(baseURL + "//goform/formNetAudio_StatusXml.xml");
+
+		assertEquals("GET //goform/formNetAudio_StatusXml.xml HTTP/1.1",
+				requestLine());
+	}
+
+	/**
+	 * HttpURLConnection fragt von sich aus gzip an, der Apache-Client tat das
+	 * nie.
+	 */
+	@Test
+	public void getDoesNotAskForGzip() throws Exception {
+		HTTPSupport.get(baseURL + "/NETAUDIO/SendPat7.asp");
+
+		assertTrue(request, hasHeader("Accept-Encoding: identity"));
+		assertFalse(request, request.toLowerCase().contains("gzip"));
+	}
+
+	@Test
+	public void postSendsFormBodyWithContentLength() throws Exception {
+		final Map<String, String> params = new LinkedHashMap<String, String>();
+		params.put("cmd0", "PutSystem_OnStandby/STANDBY");
+
+		HTTPSupport.postForm(baseURL + "/MainZone/index.put.asp", params);
+
+		assertEquals("POST /MainZone/index.put.asp HTTP/1.1", requestLine());
+		assertTrue(request,
+				hasHeader("Content-Type: application/x-www-form-urlencoded"));
+		final String expected = "cmd0=PutSystem_OnStandby%2FSTANDBY";
+		assertEquals(expected, requestBody());
+		// Der Receiver kann kein chunked - die Länge muss vorab feststehen.
+		assertTrue(request,
+				hasHeader("Content-Length: " + expected.length()));
+		assertFalse(request, request.toLowerCase().contains(
+				"transfer-encoding"));
+	}
+
+	/**
+	 * Kodierung und Reihenfolge wie beim früheren UrlEncodedFormEntity:
+	 * Leerzeichen als '+', '/' als %2F, Parameter in Einfügereihenfolge.
+	 */
+	@Test
+	public void postEncodesLikeUrlEncodedFormEntity() throws Exception {
+		final Map<String, String> params = new LinkedHashMap<String, String>();
+		params.put("cmd0", "PutNetFuncSearchNapster/jay z");
+		params.put("Key", "ART");
+		params.put("ZoneName", "MAIN ZONE");
+
+		HTTPSupport.postForm(baseURL + "/NetAudio/index.put.asp", params);
+
+		assertEquals("cmd0=PutNetFuncSearchNapster%2Fjay+z&Key=ART"
+				+ "&ZoneName=MAIN+ZONE", requestBody());
+	}
+
+	/** Der Apache-Client warf bei 4xx nicht - dieses Verhalten bleibt. */
+	@Test
+	public void errorResponseReturnsBodyInsteadOfThrowing() throws Exception {
+		responseStatus = "404 Not Found";
+		responseBody = "not found";
+
+		final byte[] content = HTTPSupport.get(baseURL + "/nope.asp");
+
+		assertEquals("not found", new String(content, "UTF-8"));
+	}
+
+	private String requestLine() {
+		return request.substring(0, request.indexOf("\r\n"));
+	}
+
+	private String requestBody() {
+		return request.substring(request.indexOf("\r\n\r\n") + 4);
+	}
+
+	private boolean hasHeader(String header) {
+		return request.contains("\r\n" + header + "\r\n");
+	}
+
+	/**
+	 * Antwortet wie der Receiver mit HTTP/1.0 und schließt danach die
+	 * Verbindung.
+	 */
+	private void serveOneRequest() {
+		try {
+			final Socket socket = server.accept();
+			try {
+				request = readRequest(socket.getInputStream());
+				final byte[] body = responseBody.getBytes("UTF-8");
+				final OutputStream out = socket.getOutputStream();
+				out.write(("HTTP/1.0 " + responseStatus + "\r\n"
+						+ "Content-Type: text/xml; charset=utf-8\r\n"
+						+ "Content-Length: " + body.length + "\r\n\r\n")
+						.getBytes("US-ASCII"));
+				out.write(body);
+				out.flush();
+			} finally {
+				socket.close();
+			}
+		} catch (IOException x) {
+			failure = x;
+		}
+	}
+
+	/** Liest Header und - falls angekündigt - den Body als rohen Text. */
+	private static String readRequest(InputStream in) throws IOException {
+		final ByteArrayOutputStream raw = new ByteArrayOutputStream();
+		int read;
+		while (!contains(raw, "\r\n\r\n") && (read = in.read()) != -1) {
+			raw.write(read);
+		}
+		final String head = raw.toString("US-ASCII");
+		final int contentLength = parseContentLength(head);
+		for (int i = 0; i < contentLength && (read = in.read()) != -1; i++) {
+			raw.write(read);
+		}
+		return raw.toString("UTF-8");
+	}
+
+	private static boolean contains(ByteArrayOutputStream buffer, String s) {
+		try {
+			return buffer.toString("US-ASCII").contains(s);
+		} catch (IOException x) {
+			throw new RuntimeException(x);
+		}
+	}
+
+	private static int parseContentLength(String head) {
+		for (String line : head.split("\r\n")) {
+			if (line.toLowerCase().startsWith("content-length:")) {
+				return Integer.parseInt(line.substring(
+						line.indexOf(':') + 1).trim());
+			}
+		}
+		return 0;
+	}
+
+	private ServerSocket server;
+	private Thread serverThread;
+	private String baseURL;
+
+	private volatile String request;
+	private volatile IOException failure;
+
+	private String responseStatus = "200 OK";
+	private String responseBody = "ok";
+}

--- a/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
@@ -198,32 +198,46 @@ public final class HTTPSupportTest {
 	 * läuft in den Lese-Timeout statt klar zu scheitern.
 	 */
 	private void serveOneRequest() {
+		final Socket socket;
 		try {
-			final Socket socket = server.accept();
-			try {
-				request = readRequest(socket.getInputStream());
-				final byte[] body = responseBody.getBytes("UTF-8");
-				final StringBuilder head = new StringBuilder("HTTP/1.0 ");
-				head.append(responseStatus).append("\r\n");
-				head.append("Content-Type: text/xml; charset=utf-8\r\n");
-				if (sendContentLength) {
-					head.append("Content-Length: ").append(body.length)
-							.append("\r\n");
-				}
-				head.append("\r\n");
-				responseHead = head.toString();
-				final OutputStream out = socket.getOutputStream();
-				out.write(responseHead.getBytes("US-ASCII"));
-				out.write(body);
-				out.flush();
-			} finally {
-				socket.close();
-			}
+			socket = server.accept();
 		} catch (IOException x) {
-			// beim Abbau ist die Exception aus accept() erwartet und darf den
-			// eigentlichen Testfehler nicht überdecken
+			// einzige Stelle, an der beim Abbau eine Exception erwartet ist -
+			// der Guard steht bewusst nur hier, sonst verschlucken die Tests
+			// echte Server-Fehler
 			if (!stopping) {
 				failure = x;
+			}
+			return;
+		}
+		try {
+			// wird der Test abgebrochen, während der Client verbunden ist,
+			// schließt server.close() diesen Socket nicht - ohne Timeout
+			// bliebe der Thread für immer in read() hängen
+			socket.setSoTimeout(SO_TIMEOUT);
+			request = readRequest(socket.getInputStream());
+			final byte[] body = responseBody.getBytes("UTF-8");
+			final StringBuilder head = new StringBuilder("HTTP/1.0 ");
+			head.append(responseStatus).append("\r\n");
+			head.append("Content-Type: text/xml; charset=utf-8\r\n");
+			if (sendContentLength) {
+				head.append("Content-Length: ").append(body.length)
+						.append("\r\n");
+			}
+			head.append("\r\n");
+			responseHead = head.toString();
+			final OutputStream out = socket.getOutputStream();
+			out.write(responseHead.getBytes("US-ASCII"));
+			out.write(body);
+			out.flush();
+		} catch (IOException x) {
+			// ab hier ist jede Exception echt
+			failure = x;
+		} finally {
+			try {
+				socket.close();
+			} catch (IOException ignore) {
+				// beim Schließen nicht mehr interessant
 			}
 		}
 	}
@@ -275,4 +289,7 @@ public final class HTTPSupportTest {
 	private volatile String responseStatus = "200 OK";
 	private volatile String responseBody = "ok";
 	private volatile boolean sendContentLength = true;
+
+	/** knapp unter dem join(5000) im Abbau, damit der Thread sicher endet */
+	private static final int SO_TIMEOUT = 4000;
 }

--- a/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
@@ -67,6 +67,11 @@ public final class HTTPSupportTest {
 		// erst schließen, dann warten: scheitert ein Test vor dem Request,
 		// hängt der Server-Thread sonst bis zum Timeout in accept()
 		stopping = true;
+		if (server == null) {
+			// startServer ist gescheitert - dessen Fehler nicht mit einer NPE
+			// von hier überdecken
+			return;
+		}
 		server.close();
 		serverThread.join(5000);
 		if (failure != null) {

--- a/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/HTTPSupportTest.java
@@ -35,14 +35,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Prüft die Eigenschaften, in denen sich HttpURLConnection vom früher benutzten
- * Apache-HttpClient unterscheidet und in denen die Receiver-Webserver (GoAhead,
- * HTTP/1.0) empfindlich sind: Content-Length statt chunked, kein gzip,
- * Content-Type und Kodierung des Formular-Bodys.
+ * Prüft das Drahtformat, das die Receiver-Webserver (GoAhead, HTTP/1.0) sehen:
+ * Request-Zeile, Content-Type und Kodierung des Formular-Bodys.
  *
  * Der Testserver ist ein roher ServerSocket, damit die Zusicherungen auf den
  * tatsächlich gesendeten Bytes sitzen und nicht auf einer geparsten Sicht
  * darauf. Es wird kein Receiver benötigt.
+ *
+ * Grenze der Aussagekraft: das hier ist die Desktop-JVM, nicht Androids
+ * OkHttp-basierte HttpURLConnection. Zwei der abgesicherten Entscheidungen
+ * lassen sich deshalb hier nicht nachweisen, nur dokumentieren - siehe die
+ * Kommentare an den betroffenen Zusicherungen.
  */
 public final class HTTPSupportTest {
 
@@ -61,8 +64,11 @@ public final class HTTPSupportTest {
 
 	@After
 	public void stopServer() throws Exception {
-		serverThread.join(5000);
+		// erst schließen, dann warten: scheitert ein Test vor dem Request,
+		// hängt der Server-Thread sonst bis zum Timeout in accept()
+		stopping = true;
 		server.close();
+		serverThread.join(5000);
 		if (failure != null) {
 			throw failure;
 		}
@@ -90,15 +96,16 @@ public final class HTTPSupportTest {
 	}
 
 	/**
-	 * HttpURLConnection fragt von sich aus gzip an, der Apache-Client tat das
-	 * nie.
+	 * Androids HttpURLConnection hängt von sich aus "Accept-Encoding: gzip" an,
+	 * der Apache-Client tat das nie. Nachweisbar ist hier nur, dass der Header
+	 * gesetzt wird - der Default, gegen den er sich richtet, existiert auf der
+	 * Desktop-JVM gar nicht.
 	 */
 	@Test
 	public void getDoesNotAskForGzip() throws Exception {
 		HTTPSupport.get(baseURL + "/NETAUDIO/SendPat7.asp");
 
 		assertTrue(request, hasHeader("Accept-Encoding: identity"));
-		assertFalse(request, request.toLowerCase().contains("gzip"));
 	}
 
 	@Test
@@ -113,7 +120,11 @@ public final class HTTPSupportTest {
 				hasHeader("Content-Type: application/x-www-form-urlencoded"));
 		final String expected = "cmd0=PutSystem_OnStandby%2FSTANDBY";
 		assertEquals(expected, requestBody());
-		// Der Receiver kann kein chunked - die Länge muss vorab feststehen.
+		// Der Receiver kann kein chunked. Achtung: diese beiden Zusicherungen
+		// halten setFixedLengthStreamingMode NICHT fest - die Desktop-JVM
+		// puffert kleine Bodies und setzt Content-Length auch ohne den Aufruf.
+		// Sie dokumentieren die Anforderung; nachgewiesen wurde sie auf dem
+		// Gerät. Ein echter Schutz bräuchte einen Instrumentation-Test.
 		assertTrue(request,
 				hasHeader("Content-Length: " + expected.length()));
 		assertFalse(request, request.toLowerCase().contains(
@@ -148,6 +159,27 @@ public final class HTTPSupportTest {
 		assertEquals("not found", new String(content, "UTF-8"));
 	}
 
+	/**
+	 * So antwortet der echte Receiver: HTTP/1.0, kein Content-Length, das Ende
+	 * des Bodys ist der Verbindungsschluss. Nachgemessen an einem AVR-3310
+	 * (GoAhead-Webs). Das ist die Antwortform, an der ein Austausch des
+	 * HTTP-Stacks am ehesten scheitert.
+	 */
+	@Test
+	public void getReadsBodyDelimitedByConnectionClose() throws Exception {
+		sendContentLength = false;
+		responseBody = "<?xml version=\"1.0\"?><item><Power>ON</Power></item>";
+
+		final byte[] content = HTTPSupport.get(baseURL
+				+ "/goform/formMainZone_MainZoneXml.xml?ZoneName=ZONE1");
+
+		// ohne diese Zusicherung wäre der Test auch dann grün, wenn der
+		// Testserver doch ein Content-Length geschickt hätte
+		assertFalse(responseHead, responseHead.toLowerCase().contains(
+				"content-length"));
+		assertEquals(responseBody, new String(content, "UTF-8"));
+	}
+
 	private String requestLine() {
 		return request.substring(0, request.indexOf("\r\n"));
 	}
@@ -162,7 +194,8 @@ public final class HTTPSupportTest {
 
 	/**
 	 * Antwortet wie der Receiver mit HTTP/1.0 und schließt danach die
-	 * Verbindung.
+	 * Verbindung. Bedient genau einen Request - ein Test, der zwei absetzt,
+	 * läuft in den Lese-Timeout statt klar zu scheitern.
 	 */
 	private void serveOneRequest() {
 		try {
@@ -170,18 +203,28 @@ public final class HTTPSupportTest {
 			try {
 				request = readRequest(socket.getInputStream());
 				final byte[] body = responseBody.getBytes("UTF-8");
+				final StringBuilder head = new StringBuilder("HTTP/1.0 ");
+				head.append(responseStatus).append("\r\n");
+				head.append("Content-Type: text/xml; charset=utf-8\r\n");
+				if (sendContentLength) {
+					head.append("Content-Length: ").append(body.length)
+							.append("\r\n");
+				}
+				head.append("\r\n");
+				responseHead = head.toString();
 				final OutputStream out = socket.getOutputStream();
-				out.write(("HTTP/1.0 " + responseStatus + "\r\n"
-						+ "Content-Type: text/xml; charset=utf-8\r\n"
-						+ "Content-Length: " + body.length + "\r\n\r\n")
-						.getBytes("US-ASCII"));
+				out.write(responseHead.getBytes("US-ASCII"));
 				out.write(body);
 				out.flush();
 			} finally {
 				socket.close();
 			}
 		} catch (IOException x) {
-			failure = x;
+			// beim Abbau ist die Exception aus accept() erwartet und darf den
+			// eigentlichen Testfehler nicht überdecken
+			if (!stopping) {
+				failure = x;
+			}
 		}
 	}
 
@@ -223,8 +266,13 @@ public final class HTTPSupportTest {
 	private String baseURL;
 
 	private volatile String request;
+	private volatile String responseHead;
 	private volatile IOException failure;
+	private volatile boolean stopping;
 
-	private String responseStatus = "200 OK";
-	private String responseBody = "ok";
+	// vom Server-Thread gelesen, von der Testmethode gesetzt - der Thread läuft
+	// schon, wenn zugewiesen wird, also volatile
+	private volatile String responseStatus = "200 OK";
+	private volatile String responseBody = "ok";
+	private volatile boolean sendContentLength = true;
 }

--- a/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
@@ -34,7 +34,8 @@ import org.junit.Test;
  * Entscheidend ist die Auswahl bei mehreren Treffern in einer Zeile: das
  * frühere führende gierige ".*" nahm das rechteste Vorkommen, nicht das erste.
  * Genau das muss die Schleife weiterhin tun - sonst liest die App auf
- * 2008er-Geräten stillschweigend die falschen Namen aus.
+ * 2008er-Geräten stillschweigend die falschen Namen aus. Beide Parser haben
+ * dafür einen eigenen Fall, weil sie die Schleife getrennt implementieren.
  *
  * Diese Klassen laufen nur gegen Receiver der 2008er-Serie, die zum Zeitpunkt
  * der Änderung nicht zum Testen zur Verfügung standen.
@@ -98,13 +99,29 @@ public final class Series08ParserTest {
 		assertEquals("Film", names.get(1));
 	}
 
+	/** Auch hier gewinnt der letzte Treffer je Zeile. */
+	@Test
+	public void quickSelectTakesRightmostMatchPerLine() throws Exception {
+		final Series08QuickSelectParser p = new Series08QuickSelectParser(
+				stream("<td name='textQuickSelectNameSelect1'"
+						+ " value=\"Falsch\"></td>"
+						+ "<td name='textQuickSelectNameSelect1'"
+						+ " value=\"Richtig\"></td>\n"));
+		p.parse();
+
+		assertEquals(1, p.get().size());
+		assertEquals("Richtig", p.get().get(0));
+	}
+
 	/**
-	 * Das von CodeQL genannte Angriffsmuster darf nicht in eine spürbare
-	 * Laufzeit laufen. Grosszügige Schranke - es geht um Polynomialverhalten,
-	 * nicht um Millisekunden.
+	 * Grosse Zeilen bleiben in linearer Zeit. Ausdrücklich KEIN Nachweis gegen
+	 * das von CodeQL gemeldete ReDoS: das alte Muster besteht diesen Test
+	 * ebenfalls in wenigen Millisekunden - ein Eingabestring, bei dem es
+	 * tatsächlich explodiert, liess sich nicht konstruieren, weil Java das
+	 * führende ".*" per Literalsuche abkürzt.
 	 */
 	@Test
-	public void pathologicalLineDoesNotBlowUp() throws Exception {
+	public void largeLineStaysFast() throws Exception {
 		final StringBuilder evil = new StringBuilder();
 		for (int i = 0; i < 5000; i++) {
 			evil.append("name='&' value=\"!");

--- a/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Sichert das Trefferverhalten der beiden Series08-Parser ab, deren
+ * OPTION_PATTERN von {@code matches()} mit umschließendem ".*" auf
+ * {@code find()} umgestellt wurde (CodeQL java/polynomial-redos).
+ *
+ * Entscheidend ist die Auswahl bei mehreren Treffern in einer Zeile: das
+ * frühere führende gierige ".*" nahm das rechteste Vorkommen, nicht das erste.
+ * Genau das muss die Schleife weiterhin tun - sonst liest die App auf
+ * 2008er-Geräten stillschweigend die falschen Namen aus.
+ *
+ * Diese Klassen laufen nur gegen Receiver der 2008er-Serie, die zum Zeitpunkt
+ * der Änderung nicht zum Testen zur Verfügung standen.
+ */
+public final class Series08ParserTest {
+
+	@Test
+	public void zoneRenameReadsNameAndValue() throws Exception {
+		final Series08ZoneRenameParser p = new Series08ZoneRenameParser(
+				stream("<html>\n"
+						+ "<input name='Main' value=\"Wohnzimmer\" />\n"
+						+ "<input name='Zone2' value=\"Kueche\" />\n"
+						+ "</html>\n"));
+		p.parse();
+
+		assertEquals("Wohnzimmer", p.getZoneName(0));
+		assertEquals("Kueche", p.getZoneName(1));
+	}
+
+	/** Bei mehreren Treffern je Zeile gewinnt der letzte - wie bisher. */
+	@Test
+	public void zoneRenameTakesRightmostMatchPerLine() throws Exception {
+		final Series08ZoneRenameParser p = new Series08ZoneRenameParser(
+				stream("<td name='Main' value=\"Falsch\"></td>"
+						+ "<td name='Main' value=\"Richtig\"></td>\n"));
+		p.parse();
+
+		assertEquals("Richtig", p.getZoneName(0));
+	}
+
+	/**
+	 * Ohne Treffer liefert getZoneNames() die Vorgabenamen - das ist die
+	 * Methode, die Series08Reader benutzt. getZoneName(int) gibt in dem Fall
+	 * null zurück, ohne Rückfall auf die Vorgabe.
+	 */
+	@Test
+	public void zoneRenameFallsBackToDefaults() throws Exception {
+		final Series08ZoneRenameParser p = new Series08ZoneRenameParser(
+				stream("<html>nichts passendes</html>\n"));
+		p.parse();
+
+		final List<String> names = p.getZoneNames();
+		assertEquals("Main", names.get(0));
+		assertEquals("Zone 2", names.get(1));
+	}
+
+	@Test
+	public void quickSelectReadsNames() throws Exception {
+		final Series08QuickSelectParser p = new Series08QuickSelectParser(
+				stream("<html>\n"
+						+ "<input name='textQuickSelectNameSelect1'"
+						+ " value=\"CD hoeren\" />\n"
+						+ "<input name='textQuickSelectNameSelect2'"
+						+ " value=\"Film\" />\n"
+						+ "</html>\n"));
+		p.parse();
+
+		final List<String> names = p.get();
+		assertEquals(2, names.size());
+		assertEquals("CD hoeren", names.get(0));
+		assertEquals("Film", names.get(1));
+	}
+
+	/**
+	 * Das von CodeQL genannte Angriffsmuster darf nicht in eine spürbare
+	 * Laufzeit laufen. Grosszügige Schranke - es geht um Polynomialverhalten,
+	 * nicht um Millisekunden.
+	 */
+	@Test
+	public void pathologicalLineDoesNotBlowUp() throws Exception {
+		final StringBuilder evil = new StringBuilder();
+		for (int i = 0; i < 5000; i++) {
+			evil.append("name='&' value=\"!");
+		}
+		evil.append("\n");
+
+		final long start = System.currentTimeMillis();
+		new Series08ZoneRenameParser(stream(evil.toString())).parse();
+		final long took = System.currentTimeMillis() - start;
+
+		assertTrue("Parsen dauerte " + took + " ms", took < 2000);
+	}
+
+	private static InputStream stream(String s) throws IOException {
+		return new ByteArrayInputStream(s.getBytes("UTF-8"));
+	}
+}


### PR DESCRIPTION
Closes the *Time bomb* item in TODO.md.

`org.apache.http` worked only because the platform still ships
`org.apache.http.legacy.jar` as an optional library. Google can drop it from any future
platform, turning this into unplanned work. The actual usage was small — 26 imports across
three files, but only GET and form POST — so `HttpURLConnection` covers it.

All requests now go through the new `http/HTTPSupport`. `useLibrary` and the manifest
`<uses-library>` are gone. Net −108 lines of production code.

## Two deliberate settings

`HttpURLConnection` differs from the old client in ways the receivers' 2008-era GoAhead
webservers care about:

- **`Accept-Encoding: identity`** — Android appends `gzip` on its own, the Apache client never
  asked for it.
- **`setFixedLengthStreamingMode`** — without a known length the body goes out chunked.

## One non-mechanical change

`AVRHTTPClient.readState` / `readQuickInfo` keep the old empty-response guard, now as a length
check. `AVRXMLInfoParser.parse` throws on an empty body, and the previous `entity != null`
branch was the graceful path that ends the zone loop. `AVRXMLInfoParserTest` pins that down.

## Tests

First tests in the project — JUnit 4, `testImplementation` only, not in the APK.

- `HTTPSupportTest` (6 cases) asserts the wire format against a raw `ServerSocket`: request
  line, double slash in the path, no gzip, `Content-Length` instead of chunked, form encoding
  (`%2F`, `+`, parameter order), and that 4xx returns a body instead of throwing.
- `AVRXMLInfoParserTest` (1 case) documents why the length check exists.

## Verification against an AVR-3310

Captured through a logging proxy, before and after:

- **GET** — request lines, `Host` and `Connection` byte-identical across all four endpoints and
  both zones. Only `Accept-Encoding: identity` and a `Dalvik/…` User-Agent are added; the Apache
  client sent no User-Agent at all.
- **POST** — verified by running `HTTPSupport` as a dex on the device's own runtime, since the
  desktop JVM buffers small bodies and would send `Content-Length` either way. On device:
  `Content-Length: 34`, no `Transfer-Encoding`, body `cmd0=PutSystem_OnStandby%2FSTANDBY`.
- **Parse path** — direct against the receiver, 4× `code:200`, XML parsed, real configured input
  names came through.

## Found along the way, filed in TODO.md, not fixed here

- `AVRXMLInfoParser` only works on Android: it reads SAX `localName`, which a standard
  non-namespace-aware `SAXParserFactory` leaves empty. Android's Expat parser fills it anyway.
  This is why the parser has no positive unit test.
- `NetDisplay.doHTTPMove()` / `doHTTPSeries08Move()` are unreachable — `AbstractModel` returns
  `DisplayMoveMode.Classic` and no model overrides it. Ported unchanged rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWxYnjqiXjuHLtLKB2Gnvh
