### PR TITLE
Fix the log attachment: content URI and scoped storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,10 +142,12 @@ Consequences:
   would pull the whole legacy UI stack into a migration. This is why `log/LogFileProvider` is a
   hand-written `ContentProvider` and not `androidx.core.content.FileProvider`: it exists only to hand
   the zipped log to the mail app as a content URI (`log/SDLogger.getLogURI()` →
-  `log/FeedbackReporter.sendMail()`, which must set `FLAG_GRANT_READ_URI_PERMISSION`). It serves
-  exactly one file name out of `SDLogger.getLogDir()`, read-only, and the canonical-path check in
-  `resolve()` is the traversal guard the AndroidX class would otherwise provide. The platform
-  `android.content.FileProvider` is no substitute — it only exists from API 34, minSdk is 24.
+  `log/FeedbackReporter.sendMail()`, which must set `FLAG_GRANT_READ_URI_PERMISSION`). There is no
+  platform equivalent to fall back to at any API level — `FileProvider` has only ever shipped in the
+  support library and AndroidX; the framework has no such class. It serves exactly one file name out
+  of `SDLogger.getLogDir()`, read-only. The traversal guard is the `ZIP_NAME` comparison in
+  `resolve()`: the file name is a constant and is only *checked* against the URI, never taken from
+  it. Do not "harden" that with a canonical-path check — it could not fail.
 - The UI is built on deprecated bases: `TabActivity`, `ListActivity`, `ExpandableListActivity`,
   `PreferenceActivity`, `TabHost`/`TabWidget` layouts, and pre-Holo platform themes
   (`Theme.NoTitleBar`, plus `Theme.Light` and `Theme.Dialog` used directly from the manifest).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,13 @@ Consequences:
 
 - **No AndroidX, no third-party dependencies.** `app/build.gradle` has no `dependencies {}` block at
   all. Everything is raw framework API. Keep it that way unless explicitly asked — adding AndroidX
-  would pull the whole legacy UI stack into a migration.
+  would pull the whole legacy UI stack into a migration. This is why `log/LogFileProvider` is a
+  hand-written `ContentProvider` and not `androidx.core.content.FileProvider`: it exists only to hand
+  the zipped log to the mail app as a content URI (`log/SDLogger.getLogURI()` →
+  `log/FeedbackReporter.sendMail()`, which must set `FLAG_GRANT_READ_URI_PERMISSION`). It serves
+  exactly one file name out of `SDLogger.getLogDir()`, read-only, and the canonical-path check in
+  `resolve()` is the traversal guard the AndroidX class would otherwise provide. The platform
+  `android.content.FileProvider` is no substitute — it only exists from API 34, minSdk is 24.
 - The UI is built on deprecated bases: `TabActivity`, `ListActivity`, `ExpandableListActivity`,
   `PreferenceActivity`, `TabHost`/`TabWidget` layouts, and pre-Holo platform themes
   (`Theme.NoTitleBar`, plus `Theme.Light` and `Theme.Dialog` used directly from the manifest).
@@ -150,8 +156,8 @@ Consequences:
 - **Within Java 11, write modern Java.** The code dates from 2010 and mostly predates it, but new and
   touched code should not imitate that. In particular use **try-with-resources** rather than the
   manual `try { … } finally { x.close(); }` pattern — `http/HTTPSupport` is the reference. The old
-  pattern is still in 13 places (`core/Connector`, `core/MacroManager`, `log/FeedbackReporter`,
-  `log/SDLogger`, the three `http/Series08*Parser`, `core/RenameService`, `scan/AVRTargetTester`);
+  pattern is still in 12 places (`core/Connector`, `core/MacroManager`, `log/FeedbackReporter`,
+  the three `http/Series08*Parser`, `core/RenameService`, `scan/AVRTargetTester`);
   converting one is welcome when you are editing that code anyway, but do not sweep the tree as a
   side errand — and note `core/Connector.java:168` is not convertible at all, it closes the socket
   only on the failure path (`if (!ok)`). The other reason to keep the manual form is when
@@ -183,10 +189,6 @@ Three things are easy to forget and all are required at `targetSdk 36`:
 Do not treat these as regressions; they predate the SDK 36 upgrade. Fixes are tracked in
 [TODO.md](TODO.md) → *Broken today*:
 
-- `log/SDLogger` writes to `Environment.getExternalStorageDirectory()` — fails under scoped storage
-  since Android 10. `WRITE_EXTERNAL_STORAGE` in the manifest has been a no-op since Android 11.
-- `SDLogger.getLogURI()` returns a `file://` URI that `log/FeedbackReporter` puts into
-  `Intent.EXTRA_STREAM` — throws `FileUriExposedException`. Sending logs needs a `FileProvider`.
 - The custom-background picker (`AVRSettings`) stores the URI without
   `takePersistableUriPermission()`, so it does not survive a restart.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,14 +6,20 @@ blocks the current build, which is green.
 
 ## Broken today
 
-- [ ] **Sending logs does not work.** `SDLogger.getLogURI()` returns a `file://` URI,
-      `log/FeedbackReporter.java:93` puts it into `Intent.EXTRA_STREAM` → `FileUriExposedException`
-      since targetSdk 24. This is the app's own support channel ("Feedback" in the options menu).
-      Fix: add a `FileProvider` and hand out a content URI.
-- [ ] **`SDLogger` writes to `Environment.getExternalStorageDirectory()`**, which fails under
-      scoped storage (Android 10+). Move to `getExternalFilesDir(null)`.
-- [ ] Once both are done, drop `WRITE_EXTERNAL_STORAGE` from the manifest — it has been a no-op
-      since Android 11. (Until then it should at least carry `android:maxSdkVersion="28"`.)
+- [x] **Sending logs does not work.** `SDLogger.getLogURI()` returned a `file://` URI which
+      `log/FeedbackReporter` put into `Intent.EXTRA_STREAM` → `FileUriExposedException` since
+      targetSdk 24. Now handed out as a content URI by `log/LogFileProvider`, with
+      `FLAG_GRANT_READ_URI_PERMISSION` on the intent. The provider is written by hand rather than
+      derived from `androidx.core`: the project has no dependencies (CLAUDE.md), and the platform
+      `android.content.FileProvider` only exists from API 34 while minSdk is 24. It serves exactly
+      one file name from the log directory, read-only, and is `exported="false"`.
+- [x] **`SDLogger` writes to `Environment.getExternalStorageDirectory()`**, which fails under
+      scoped storage (Android 10+). Moved to `getExternalFilesDir(null)`, falling back to
+      `getFilesDir()`. The `MEDIA_MOUNTED`/`MEDIA_REMOVED` receiver went with it — an app-specific
+      directory is always there — which also fixes the leak from `stopWatchingExternalStorage()`
+      never having had a caller.
+- [x] Once both are done, drop `WRITE_EXTERNAL_STORAGE` from the manifest — it has been a no-op
+      since Android 11.
 
 ## Next platform deadline: targetSdk 37
 
@@ -103,12 +109,12 @@ blocks the current build, which is green.
 - [ ] `versionCode` (124) and `versionName` (1.5.1) still sit in the manifest unchanged and must be
       raised before any release. The release workflow triggers on a `v*` tag and needs the
       `KEY_JKS`, `KEY_PASSWORD`, `KEY_ALIAS` and `STORE_PASSWORD` secrets.
-- [ ] **13 manual `try { … } finally { close(); }` blocks left** in `core/Connector`,
+- [ ] **12 manual `try { … } finally { close(); }` blocks left** in `core/Connector`,
       `core/MacroManager`, `core/RenameService`, `scan/AVRTargetTester`, the three
-      `http/Series08*Parser`, `log/FeedbackReporter` and `log/SDLogger`. try-with-resources is the
+      `http/Series08*Parser` and `log/FeedbackReporter`. try-with-resources is the
       convention now (see CLAUDE.md); `http/HTTPSupport` is the reference. Worth converting in
-      passing rather than as its own sweep — `log/FeedbackReporter` and `log/SDLogger` are due for
-      the FileProvider work anyway, so they come for free there.
+      passing rather than as its own sweep — `log/SDLogger` came for free with the FileProvider
+      work above, `log/FeedbackReporter` was not touched there.
 - [ ] `misc/add-copyright.sh` still uses the pre-Gradle path (`../src/**/*.java` instead of
       `app/src/main/...`), so it currently matches nothing.
 - [ ] `misc/createicons.sh` looks obsolete and should probably just be deleted: it writes 46 plain

--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,10 @@ blocks the current build, which is green.
       `log/FeedbackReporter` put into `Intent.EXTRA_STREAM` → `FileUriExposedException` since
       targetSdk 24. Now handed out as a content URI by `log/LogFileProvider`, with
       `FLAG_GRANT_READ_URI_PERMISSION` on the intent. The provider is written by hand rather than
-      derived from `androidx.core`: the project has no dependencies (CLAUDE.md), and the platform
-      `android.content.FileProvider` only exists from API 34 while minSdk is 24. It serves exactly
-      one file name from the log directory, read-only, and is `exported="false"`.
+      derived from `androidx.core`: the project has no dependencies (CLAUDE.md), and there is no
+      platform `FileProvider` at any API level to fall back to — the class has only ever existed in
+      the support library and AndroidX. It serves exactly one file name from the log directory,
+      read-only, and is `exported="false"`.
 - [x] **`SDLogger` writes to `Environment.getExternalStorageDirectory()`**, which fails under
       scoped storage (Android 10+). Moved to `getExternalFilesDir(null)`, falling back to
       `getFilesDir()`. The `MEDIA_MOUNTED`/`MEDIA_REMOVED` receiver went with it — an app-specific
@@ -128,7 +129,10 @@ blocks the current build, which is green.
       whole `-v14` qualifier as pointless at minSdk 24.
 - [ ] `allowBackup="true"` without `dataExtractionRules`. Not a bug — the API 31 default backs
       everything up, including receiver IPs in the SharedPreferences — but an explicit rule would be
-      cleaner.
+      cleaner. Note this got wider when the log moved to `getExternalFilesDir(null)`: that directory
+      is inside the default full-backup scope, the old shared-external `AVRRemote/` was not, so with
+      logging enabled the log files and `avrremote.zip` — which contain the same receiver IPs, via
+      `AVRSettings.getAll()` — now travel with the backup too.
 - [ ] Dead version check: `StatusbarManager.java:50` gates on `SDK_INT >= JELLY_BEAN`, always true
       at minSdk 24 (lint: `ObsoleteSdkInt`). The `if` wraps lines 51–74; the `Context`/`Intent`/
       `PendingIntent` setup above it stays.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,8 +14,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" >
     </uses-permission>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" >
-    </uses-permission>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" >
     </uses-permission>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" >
@@ -69,6 +67,12 @@
             android:exported="false"
             android:label="Options"
             android:theme="@android:style/Theme.Dialog" />
+
+        <provider
+            android:name=".log.LogFileProvider"
+            android:authorities="de.pskiwi.avrremote.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/de/pskiwi/avrremote/log/FeedbackReporter.java
+++ b/app/src/main/java/de/pskiwi/avrremote/log/FeedbackReporter.java
@@ -91,6 +91,8 @@ public final class FeedbackReporter {
 				final Uri uri = sdLogger.getLogURI();
 				if (uri != null) {
 					emailIntent.putExtra(Intent.EXTRA_STREAM, uri);
+					emailIntent
+							.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 				}
 			}
 

--- a/app/src/main/java/de/pskiwi/avrremote/log/LogFileProvider.java
+++ b/app/src/main/java/de/pskiwi/avrremote/log/LogFileProvider.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.log;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import android.content.ContentProvider;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.provider.OpenableColumns;
+
+/**
+ * Gibt das gezippte Log als content-URI heraus. Ein FileProvider von Hand,
+ * weil das Projekt bewusst ohne AndroidX auskommt und
+ * android.content.FileProvider erst ab API 34 existiert.
+ */
+public final class LogFileProvider extends ContentProvider {
+
+	public static Uri uriFor(File file) {
+		return new Uri.Builder().scheme(ContentResolver.SCHEME_CONTENT)
+				.authority(AUTHORITY).appendPath(file.getName()).build();
+	}
+
+	@Override
+	public boolean onCreate() {
+		return true;
+	}
+
+	@Override
+	public ParcelFileDescriptor openFile(Uri uri, String mode)
+			throws FileNotFoundException {
+		if (!"r".equals(mode)) {
+			throw new FileNotFoundException("read-only: " + uri);
+		}
+		return ParcelFileDescriptor.open(resolve(uri),
+				ParcelFileDescriptor.MODE_READ_ONLY);
+	}
+
+	@Override
+	public String getType(Uri uri) {
+		return "application/zip";
+	}
+
+	/**
+	 * Ohne DISPLAY_NAME/SIZE nennen viele Mail-Apps den Anhang "null" oder
+	 * verwerfen ihn.
+	 */
+	@Override
+	public Cursor query(Uri uri, String[] projection, String selection,
+			String[] selectionArgs, String sortOrder) {
+		final File file;
+		try {
+			file = resolve(uri);
+		} catch (FileNotFoundException x) {
+			return null;
+		}
+		final String[] columns = projection != null ? projection
+				: new String[] { OpenableColumns.DISPLAY_NAME,
+						OpenableColumns.SIZE };
+		final Object[] values = new Object[columns.length];
+		for (int i = 0; i < columns.length; i++) {
+			if (OpenableColumns.DISPLAY_NAME.equals(columns[i])) {
+				values[i] = file.getName();
+			} else if (OpenableColumns.SIZE.equals(columns[i])) {
+				values[i] = file.length();
+			}
+		}
+		final MatrixCursor cursor = new MatrixCursor(columns, 1);
+		cursor.addRow(values);
+		return cursor;
+	}
+
+	@Override
+	public Uri insert(Uri uri, ContentValues values) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int update(Uri uri, ContentValues values, String selection,
+			String[] selectionArgs) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int delete(Uri uri, String selection, String[] selectionArgs) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Genau eine Datei ist erreichbar. Der Canonical-Vergleich fängt zusätzlich
+	 * alles ab, was per Pfad-Trick aus dem Log-Verzeichnis herausführt.
+	 */
+	private File resolve(Uri uri) throws FileNotFoundException {
+		final Context ctx = getContext();
+		if (ctx == null) {
+			throw new FileNotFoundException("no context: " + uri);
+		}
+		if (!SDLogger.ZIP_NAME.equals(uri.getLastPathSegment())
+				|| uri.getPathSegments().size() != 1) {
+			throw new FileNotFoundException("unknown file: " + uri);
+		}
+		final File logdir = SDLogger.getLogDir(ctx);
+		final File file = new File(logdir, SDLogger.ZIP_NAME);
+		try {
+			if (!file.getCanonicalFile().getParentFile()
+					.equals(logdir.getCanonicalFile())) {
+				throw new FileNotFoundException("outside log dir: " + uri);
+			}
+		} catch (IOException x) {
+			throw new FileNotFoundException("cannot resolve: " + uri);
+		}
+		if (!file.canRead()) {
+			throw new FileNotFoundException("not readable: " + uri);
+		}
+		return file;
+	}
+
+	public static final String AUTHORITY = "de.pskiwi.avrremote.fileprovider";
+
+}

--- a/app/src/main/java/de/pskiwi/avrremote/log/LogFileProvider.java
+++ b/app/src/main/java/de/pskiwi/avrremote/log/LogFileProvider.java
@@ -18,7 +18,8 @@ package de.pskiwi.avrremote.log;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import android.content.ContentProvider;
 import android.content.ContentResolver;
@@ -31,9 +32,10 @@ import android.os.ParcelFileDescriptor;
 import android.provider.OpenableColumns;
 
 /**
- * Gibt das gezippte Log als content-URI heraus. Ein FileProvider von Hand,
- * weil das Projekt bewusst ohne AndroidX auskommt und
- * android.content.FileProvider erst ab API 34 existiert.
+ * Gibt das gezippte Log als content-URI heraus. Ein FileProvider von Hand, weil
+ * es den fertigen nur in AndroidX gibt (androidx.core.content.FileProvider) und
+ * das Projekt bewusst ohne Abhängigkeiten auskommt - im Framework selbst
+ * existiert keine FileProvider-Klasse.
  */
 public final class LogFileProvider extends ContentProvider {
 
@@ -64,7 +66,9 @@ public final class LogFileProvider extends ContentProvider {
 
 	/**
 	 * Ohne DISPLAY_NAME/SIZE nennen viele Mail-Apps den Anhang "null" oder
-	 * verwerfen ihn.
+	 * verwerfen ihn. Nicht erkannte Spalten fallen aus dem Ergebnis heraus,
+	 * statt mit null aufzutauchen: fragt eine App nach MediaColumns.DATA, soll
+	 * sie eine fehlende Spalte sehen und nicht einen Pfad, der null ist.
 	 */
 	@Override
 	public Cursor query(Uri uri, String[] projection, String selection,
@@ -75,18 +79,22 @@ public final class LogFileProvider extends ContentProvider {
 		} catch (FileNotFoundException x) {
 			return null;
 		}
-		final String[] columns = projection != null ? projection
+		final String[] requested = projection != null ? projection
 				: new String[] { OpenableColumns.DISPLAY_NAME,
 						OpenableColumns.SIZE };
-		final Object[] values = new Object[columns.length];
-		for (int i = 0; i < columns.length; i++) {
-			if (OpenableColumns.DISPLAY_NAME.equals(columns[i])) {
-				values[i] = file.getName();
-			} else if (OpenableColumns.SIZE.equals(columns[i])) {
-				values[i] = file.length();
+		final List<String> columns = new ArrayList<>(requested.length);
+		final List<Object> values = new ArrayList<>(requested.length);
+		for (String column : requested) {
+			if (OpenableColumns.DISPLAY_NAME.equals(column)) {
+				columns.add(column);
+				values.add(file.getName());
+			} else if (OpenableColumns.SIZE.equals(column)) {
+				columns.add(column);
+				values.add(file.length());
 			}
 		}
-		final MatrixCursor cursor = new MatrixCursor(columns, 1);
+		final MatrixCursor cursor = new MatrixCursor(
+				columns.toArray(new String[0]), 1);
 		cursor.addRow(values);
 		return cursor;
 	}
@@ -108,28 +116,20 @@ public final class LogFileProvider extends ContentProvider {
 	}
 
 	/**
-	 * Genau eine Datei ist erreichbar. Der Canonical-Vergleich fängt zusätzlich
-	 * alles ab, was per Pfad-Trick aus dem Log-Verzeichnis herausführt.
+	 * Genau eine Datei ist erreichbar. Der Schutz gegen Pfad-Tricks ist der
+	 * Vergleich mit ZIP_NAME: der Dateiname kommt nicht aus der URI, er wird
+	 * nur gegen sie geprüft. Ein Canonical-Vergleich hinterher wäre toter Code.
 	 */
 	private File resolve(Uri uri) throws FileNotFoundException {
 		final Context ctx = getContext();
 		if (ctx == null) {
 			throw new FileNotFoundException("no context: " + uri);
 		}
-		if (!SDLogger.ZIP_NAME.equals(uri.getLastPathSegment())
-				|| uri.getPathSegments().size() != 1) {
+		if (uri.getPathSegments().size() != 1
+				|| !SDLogger.ZIP_NAME.equals(uri.getLastPathSegment())) {
 			throw new FileNotFoundException("unknown file: " + uri);
 		}
-		final File logdir = SDLogger.getLogDir(ctx);
-		final File file = new File(logdir, SDLogger.ZIP_NAME);
-		try {
-			if (!file.getCanonicalFile().getParentFile()
-					.equals(logdir.getCanonicalFile())) {
-				throw new FileNotFoundException("outside log dir: " + uri);
-			}
-		} catch (IOException x) {
-			throw new FileNotFoundException("cannot resolve: " + uri);
-		}
+		final File file = new File(SDLogger.getLogDir(ctx), SDLogger.ZIP_NAME);
 		if (!file.canRead()) {
 			throw new FileNotFoundException("not readable: " + uri);
 		}

--- a/app/src/main/java/de/pskiwi/avrremote/log/SDLogger.java
+++ b/app/src/main/java/de/pskiwi/avrremote/log/SDLogger.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.logging.FileHandler;
@@ -30,12 +31,8 @@ import java.util.logging.SimpleFormatter;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.net.Uri;
-import android.os.Environment;
 import android.util.Log;
 
 public final class SDLogger implements ILogger {
@@ -72,115 +69,57 @@ public final class SDLogger implements ILogger {
 	}
 
 	public SDLogger(Context ctx) {
-		this.ctx = ctx;
-		logdir = new File(Environment.getExternalStorageDirectory(), DIR_NAME);
+		logdir = getLogDir(ctx);
 		logger.setLevel(Level.FINE);
-		startWatchingExternalStorage();
+		try {
+			currentHandler = new SDHandler();
+			logger.addHandler(currentHandler);
+			logger.info("openend at " + new Date());
+		} catch (IOException e) {
+			currentHandler = null;
+			Log.e(ADBLogger.TAG, "set sdlogger failed", e);
+		}
 	}
 
-	void updateExternalStorageState() {
-		boolean oldState = mExternalStorageWriteable;
-		String state = Environment.getExternalStorageState();
-		if (Environment.MEDIA_MOUNTED.equals(state)) {
-			mExternalStorageAvailable = mExternalStorageWriteable = true;
-		} else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
-			mExternalStorageAvailable = true;
-			mExternalStorageWriteable = false;
-		} else {
-			mExternalStorageAvailable = mExternalStorageWriteable = false;
-		}
-
-		if (oldState != mExternalStorageAvailable) {
-			Log.i(ADBLogger.TAG, "external storage writable " + oldState + "->"
-					+ mExternalStorageAvailable);
-			if (mExternalStorageWriteable) {
-				try {
-					if (!logdir.exists()) {
-						boolean mkdir = logdir.mkdir();
-						if (!mkdir) {
-							Log.e(ADBLogger.TAG,
-									"could not create "
-											+ logdir.getAbsolutePath());
-						}
-					}
-					currentHandler = new SDHandler();
-					logger.addHandler(currentHandler);
-					logger.info("openend at " + new Date());
-				} catch (IOException e) {
-					currentHandler = null;
-					Log.e(ADBLogger.TAG, "set sdlogger failed", e);
-				}
-
-			} else {
-				if (currentHandler != null) {
-					logger.removeHandler(currentHandler);
-					currentHandler.close();
-					currentHandler = null;
-				}
-
-			}
-		}
-
+	/**
+	 * App-eigenes Verzeichnis auf dem externen Speicher - unter Scoped Storage
+	 * (Android 10+) der einzige Ort, an den ohne Permission geschrieben werden
+	 * darf. Ist kein externer Speicher da, geht es nach intern.
+	 */
+	static File getLogDir(Context ctx) {
+		final File ext = ctx.getExternalFilesDir(null);
+		return ext != null ? ext : ctx.getFilesDir();
 	}
 
 	public Uri getLogURI() {
-		File f = new File(logdir.getAbsolutePath() + File.separator + LOG_NAME
-				+ "-" + 0 + ".log");
+		final File f = new File(logdir, LOG_NAME + "-0.log");
 		Log.i(ADBLogger.TAG, "log: " + f.getAbsolutePath() + " " + f.canRead());
 		if (f.canRead()) {
 			final File copy = createZip(f);
 			if (copy != null) {
-				return Uri.fromFile(copy);
+				return LogFileProvider.uriFor(copy);
 			}
 		}
 		return null;
 	}
 
 	private File createZip(File f) {
-		final File writeTo = new File(logdir.getAbsolutePath() + File.separator
-				+ LOG_NAME + ".zip");
-		long length = f.length();
-		byte[] buffer = new byte[(int) length];
-		try {
-			final FileOutputStream out = new FileOutputStream(writeTo);
-			final FileInputStream in = new FileInputStream(f);
-			final ZipOutputStream zout = new ZipOutputStream(out);
-			try {
-				zout.putNextEntry(new ZipEntry(LOG_NAME + ".log"));
-				in.read(buffer);
-				zout.write(buffer);
-				zout.closeEntry();
-			} catch (Exception x) {
-				Log.e(ADBLogger.TAG, "copy log failed", x);
-				return null;
-			} finally {
-				in.close();
-				zout.close();
+		final File writeTo = new File(logdir, ZIP_NAME);
+		final byte[] buffer = new byte[8192];
+		try (InputStream in = new FileInputStream(f);
+				ZipOutputStream zout = new ZipOutputStream(
+						new FileOutputStream(writeTo))) {
+			zout.putNextEntry(new ZipEntry(LOG_NAME + ".log"));
+			int read;
+			while ((read = in.read(buffer)) > 0) {
+				zout.write(buffer, 0, read);
 			}
+			zout.closeEntry();
 		} catch (Exception x) {
 			Log.e(ADBLogger.TAG, "copy log failed", x);
 			return null;
 		}
 		return writeTo;
-	}
-
-	void startWatchingExternalStorage() {
-		mExternalStorageReceiver = new BroadcastReceiver() {
-			@Override
-			public void onReceive(Context context, Intent intent) {
-				Log.i(ADBLogger.TAG, "Storage: " + intent.getData());
-				updateExternalStorageState();
-			}
-		};
-		IntentFilter filter = new IntentFilter();
-		filter.addAction(Intent.ACTION_MEDIA_MOUNTED);
-		filter.addAction(Intent.ACTION_MEDIA_REMOVED);
-		ctx.registerReceiver(mExternalStorageReceiver, filter);
-		updateExternalStorageState();
-	}
-
-	void stopWatchingExternalStorage() {
-		ctx.unregisterReceiver(mExternalStorageReceiver);
 	}
 
 	public void debug(String s) {
@@ -206,10 +145,6 @@ public final class SDLogger implements ILogger {
 	}
 
 	private SDHandler currentHandler;
-	private BroadcastReceiver mExternalStorageReceiver;
-	private boolean mExternalStorageAvailable = false;
-	private boolean mExternalStorageWriteable = false;
-	private final Context ctx;
 
 	private static final int MAX_FILE = 3;
 	private static final int FILE_SIZE = 500 * 1024;
@@ -219,6 +154,6 @@ public final class SDLogger implements ILogger {
 	private final static java.text.DateFormat DATE_FORMAT = new SimpleDateFormat(
 			"yyyy-MM-dd  HH:mm:ss.SSS");
 	private final static String LOG_NAME = "avrremote";
-	private final static String DIR_NAME = "AVRRemote";
+	final static String ZIP_NAME = LOG_NAME + ".zip";
 
 }

--- a/app/src/main/java/de/pskiwi/avrremote/log/SDLogger.java
+++ b/app/src/main/java/de/pskiwi/avrremote/log/SDLogger.java
@@ -139,6 +139,11 @@ public final class SDLogger implements ILogger {
 
 	public void close() {
 		if (currentHandler != null) {
+			// logger ist der prozessweite JUL-Logger "avrremote", nicht einer
+			// pro SDLogger. Ohne removeHandler sammelt jedes Umschalten des
+			// Log-Modus einen geschlossenen Handler dort an, der über seine
+			// äußere Instanz den ganzen SDLogger festhält.
+			logger.removeHandler(currentHandler);
 			currentHandler.close();
 			currentHandler = null;
 		}


### PR DESCRIPTION
Closes the three *Broken today* items in TODO.md — the app's own support channel ("Feedback" in the options menu) has been broken twice over.

## What was wrong

1. **No log file existed.** `SDLogger` wrote to `Environment.getExternalStorageDirectory()/AVRRemote`, which scoped storage has refused since Android 10. `mkdir` failed, the `FileHandler` was never created, and the only trace was a `Log.e`. Verified on an API 36 emulator: `/sdcard/AVRRemote` does not exist.
2. **And it could not have been attached.** `getLogURI()` returned a `file://` URI that `FeedbackReporter` put into `Intent.EXTRA_STREAM` → `FileUriExposedException` since targetSdk 24.

## What changed

- **`log/SDLogger`** — logs go to `getExternalFilesDir(null)`, falling back to `getFilesDir()`. That makes the `MEDIA_MOUNTED`/`MEDIA_REMOVED` receiver pointless, so it goes, together with the leak from `stopWatchingExternalStorage()` never having had a caller; the handler is opened straight from the constructor. `close()` now also detaches the handler from the process-wide JUL logger — the removed code was the only place that did. `createZip()` picks up try-with-resources and a real copy loop instead of the single `in.read(byte[length])` that could short-read.
- **`log/LogFileProvider`** (new) — hands the zip out as a content URI. Written by hand because the ready-made one exists only in AndroidX (`androidx.core.content.FileProvider`) and this project deliberately has no dependencies; there is no platform `FileProvider` at any API level to fall back to. It serves exactly one file name out of the log directory, read-only, and is `exported="false"`. The traversal guard is the `ZIP_NAME` comparison: the file name is a constant and is only *checked* against the URI, never taken from it. `query()` drops columns it does not know rather than returning them as null, so a client asking for `MediaColumns.DATA` sees a missing column instead of a null path.
- **`log/FeedbackReporter`** — `FLAG_GRANT_READ_URI_PERMISSION` on the intent. The wrong `setType("plain/text")` is left alone; it decides which apps appear in the chooser and does not belong in this change.
- **Manifest** — `WRITE_EXTERNAL_STORAGE` dropped (a no-op since Android 11), `<provider>` added.

The second commit applies the findings of a code review of the first.

## Verification

`./gradlew build` is green, but proves nothing here — `src/test` covers neither `log/` nor anything Android-specific. Checked on an API 36 emulator instead:

- With `debugMode=file`, `avrremote-0.log` appears in `Android/data/de.pskiwi.avrremote/files/` and logcat reports the handler opening without error.
- Menu → Feedback → *Attach log-file* → OK: the share sheet opens, **no `FileUriExposedException`**, `avrremote.zip` is written.
- Provider queried directly: the default projection gives `_display_name=avrremote.zip, _size=4586`; `--projection _data` gives a row with no columns; `_display_name:_data` gives only the name. The stream is a valid zip holding the complete log.
- An unknown file name and a multi-segment path (`/sub/avrremote.zip`) are both rejected with `FileNotFoundException`; an unprivileged caller gets `SecurityException: … not exported`.
- Log mode *file → adb → file* in the settings reopens generation 0 and keeps appending, with no `%u`-suffixed fallback file and no duplicated lines — i.e. the old handler really is released.

Two things could not be checked: Gmail on the emulator has no account and never reaches the compose screen, so the attachment chip itself was not seen — what a mail app fetches (`query` + `openFile`) is verified instead. And `getType` could not be exercised through `adb shell content gettype`, which NPEs in the shell tool itself; it returns a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6DnkfZvdQSMzd9t31bUff