### PR TITLE
Cover the model reflection registry with a test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@ verify on a device or emulator instead. Three limits are worth knowing before wr
 - A test that reads project files from disk rather than from the classpath — `res/` and `src/` are
   on neither — must be declared as a task input, or Gradle calls the test up to date on exactly the
   change it exists to catch. `ModelConfiguratorTest` reads `res/values/lists.xml`, hence the
-  `tasks.withType(Test) { inputs.file(...) }` block at the bottom of `app/build.gradle`. It also
+  `tasks.withType(Test).configureEach { inputs.file(...) }` block at the bottom of `app/build.gradle`
+  (it covers both variants — verified by watching `testReleaseUnitTest` re-run too). It also
   resolves its paths against both the module and the root directory, because the working directory
   depends on how the run was started.
 
@@ -137,10 +138,11 @@ Consequences:
   `@array/modelNames` in `res/values/lists.xml`. The names must correspond after dash-stripping.
   Both sides currently hold exactly 60 entries and resolve 1:1 — if they drift apart, the orphaned
   name falls back to `AVRGeneric` and the user just silently misses features. `ModelConfiguratorTest`
-  is what turns that silent drift into a red build, in both directions; the normalisation it drives
-  lives in `ModelConfigurator.createModel(String)`, split out of `update()` so the test does not have
-  to reimplement it. (Note `lists.xml` holds 130 `<item>`s across 14 arrays; only the 60 in
-  `modelNames` are receivers.)
+  is what turns that silent drift into a red build, in both directions; it drives the real lookup in
+  `ModelConfigurator.createModel(String)`, split out of `update()` because there it sat behind a
+  `Context`. Its own `expectedClassName` restates the dash and `(experimental)` stripping on purpose
+  — that second copy is what pins the naming convention. (Note `lists.xml` holds 130 `<item>`s
+  across 14 arrays; only the 60 in `modelNames` are receivers.)
 - The model classes have no static references. Never enable R8/ProGuard shrinking without a
   keep rule for `de.pskiwi.avrremote.models.**`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,12 +27,12 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
-**There is almost no test coverage.** `src/test` holds three JVM test classes —
-`http/HTTPSupportTest` (7 cases), `http/Series08ParserTest` (5) and `http/AVRXMLInfoParserTest` (1),
-JUnit 4 being the only dependency in the project — and there is no `src/androidTest` at all.
-`./gradlew test` runs those thirteen cases and nothing else (twice, in fact: once per build
-variant), so do not report a change as verified because the build passed; verify on a device or
-emulator instead. Two limits are worth knowing before writing more tests:
+**There is almost no test coverage.** `src/test` holds four JVM test classes —
+`http/HTTPSupportTest` (7 cases), `http/Series08ParserTest` (6), `models/ModelConfiguratorTest` (3)
+and `http/AVRXMLInfoParserTest` (1), JUnit 4 being the only dependency in the project — and there is
+no `src/androidTest` at all. `./gradlew test` runs those seventeen cases and nothing else (twice, in
+fact: once per build variant), so do not report a change as verified because the build passed;
+verify on a device or emulator instead. Three limits are worth knowing before writing more tests:
 
 - These run on the desktop JVM, not on Android's OkHttp-backed stack. Anything Android-specific —
   the implicit `Accept-Encoding: gzip`, chunked request bodies — cannot be pinned here, only
@@ -44,6 +44,12 @@ emulator instead. Two limits are worth knowing before writing more tests:
   `SAXParserFactoryImpl` rejects `disallow-doctype-decl` with `SAXNotRecognizedException`, so the
   parser disables `external-general-entities` and `external-parameter-entities` instead — those two
   are supported. Verified on a Pixel 8; do not "simplify" it to the usual one-liner.
+- A test that reads project files from disk rather than from the classpath — `res/` and `src/` are
+  on neither — must be declared as a task input, or Gradle calls the test up to date on exactly the
+  change it exists to catch. `ModelConfiguratorTest` reads `res/values/lists.xml`, hence the
+  `tasks.withType(Test) { inputs.file(...) }` block at the bottom of `app/build.gradle`. It also
+  resolves its paths against both the module and the root directory, because the working directory
+  depends on how the run was started.
 
 Lint runs with `abortOnError false`, so lint *errors* do not fail the build — check
 `app/build/reports/lint-results-debug.html` explicitly when it matters.
@@ -130,8 +136,11 @@ Consequences:
 - Adding a receiver needs **two** changes: a class in `models/` *and* an entry in
   `@array/modelNames` in `res/values/lists.xml`. The names must correspond after dash-stripping.
   Both sides currently hold exactly 60 entries and resolve 1:1 — if they drift apart, the orphaned
-  name falls back to `AVRGeneric` and the user just silently misses features. (Note `lists.xml` holds
-  130 `<item>`s across 14 arrays; only the 60 in `modelNames` are receivers.)
+  name falls back to `AVRGeneric` and the user just silently misses features. `ModelConfiguratorTest`
+  is what turns that silent drift into a red build, in both directions; the normalisation it drives
+  lives in `ModelConfigurator.createModel(String)`, split out of `update()` so the test does not have
+  to reimplement it. (Note `lists.xml` holds 130 `<item>`s across 14 arrays; only the 60 in
+  `modelNames` are receivers.)
 - The model classes have no static references. Never enable R8/ProGuard shrinking without a
   keep rule for `de.pskiwi.avrremote.models.**`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ blocks the current build, which is green.
 
 ## Structural
 
-- [ ] **Test coverage is three files.** `http/HTTPSupportTest`, `http/Series08ParserTest` and
+- [x] **Test coverage is three files.** `http/HTTPSupportTest`, `http/Series08ParserTest` and
       `http/AVRXMLInfoParserTest` (added with the Apache removal) set up `src/test` and the JUnit
       dependency; everything else is still uncovered. The highest-value test to add next is one for `models/ModelConfigurator`, because it
       covers a failure mode the compiler cannot see: it resolves the 60 receiver classes **by
@@ -44,6 +44,11 @@ blocks the current build, which is green.
       back to `AVRGeneric` and the user just misses features. A JVM unit test that runs all 60
       entries of `@array/modelNames` through the same normalisation and instantiates them catches
       exactly that. Both sides hold 60 entries today, so the test starts green.
+      → `models/ModelConfiguratorTest` does this in both directions (name → class, and every
+      concrete `IAVRModel` has a list entry). The normalisation moved out of `update()` into
+      `ModelConfigurator.createModel(String)` so the test drives the real code and not a copy;
+      `lists.xml` is declared as a test input in `app/build.gradle`, otherwise Gradle skips the
+      test on exactly the change it guards.
 - [ ] After that, `models/` (pure capability logic) and `core/ZoneState.java` (1237 lines) are the
       cheapest places to add coverage.
 - [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@ blocks the current build, which is green.
 
 ## Structural
 
-- [x] **Test coverage is three files.** `http/HTTPSupportTest`, `http/Series08ParserTest` and
+- [x] **Test coverage was three files.** `http/HTTPSupportTest`, `http/Series08ParserTest` and
       `http/AVRXMLInfoParserTest` (added with the Apache removal) set up `src/test` and the JUnit
       dependency; everything else is still uncovered. The highest-value test to add next is one for `models/ModelConfigurator`, because it
       covers a failure mode the compiler cannot see: it resolves the 60 receiver classes **by
@@ -45,10 +45,11 @@ blocks the current build, which is green.
       entries of `@array/modelNames` through the same normalisation and instantiates them catches
       exactly that. Both sides hold 60 entries today, so the test starts green.
       → `models/ModelConfiguratorTest` does this in both directions (name → class, and every
-      concrete `IAVRModel` has a list entry). The normalisation moved out of `update()` into
-      `ModelConfigurator.createModel(String)` so the test drives the real code and not a copy;
-      `lists.xml` is declared as a test input in `app/build.gradle`, otherwise Gradle skips the
-      test on exactly the change it guards.
+      concrete `IAVRModel` has a list entry). The reflection moved out of `update()` into
+      `ModelConfigurator.createModel(String)`, which is what the test drives; the dash and
+      `(experimental)` stripping is deliberately spelled out a second time in the test, so that
+      changing the convention shows up as a failure. `lists.xml` is declared as a test input in
+      `app/build.gradle`, otherwise Gradle skips the test on exactly the change it guards.
 - [ ] After that, `models/` (pure capability logic) and `core/ZoneState.java` (1237 lines) are the
       cheapest places to add coverage.
 - [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,4 +58,11 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 }
 
+// ModelConfiguratorTest liest lists.xml direkt von der Platte, nicht über den
+// Classpath. Ohne diese Zeile hält Gradle den Test für aktuell, wenn genau die
+// Datei sich ändert, um die es dabei geht.
+tasks.withType(Test).configureEach {
+    inputs.file("src/main/res/values/lists.xml")
+}
+
 

--- a/app/src/main/java/de/pskiwi/avrremote/models/ModelConfigurator.java
+++ b/app/src/main/java/de/pskiwi/avrremote/models/ModelConfigurator.java
@@ -41,18 +41,6 @@ public final class ModelConfigurator {
 	}
 
 	public void update() {
-		// "AVR-3310" -> "AVR3310"
-		final String am = AVRSettings.getAVRModel(ctx, currentReceiver)
-				.replace("-", "").trim();
-		final String avrModel;
-		// "(experimental)" weg
-		int p = am.indexOf("(");
-		if (p != -1) {
-			avrModel = am.substring(0, p).trim();
-		} else {
-			avrModel = am;
-		}
-
 		// "North America" -> "NorthAmerica"
 		final String avrModelArea = AVRSettings.getAVRModelArea(ctx)
 				.replace(" ", "").trim();
@@ -62,22 +50,43 @@ public final class ModelConfigurator {
 			area = ModelArea.valueOf(avrModelArea);
 		}
 		Logger.info("Area set to " + area);
-		if (avrModel.length() == 0) {
-			model = new AVRGeneric();
-		} else {
-			try {
-				model = (IAVRModel) Class.forName(
-						"de.pskiwi.avrremote.models." + avrModel).newInstance();
-			} catch (Exception x) {
-				Logger.error("create " + avrModel + " failed", x);
-				model = new AVRGeneric();
-			}
-		}
+		model = createModel(AVRSettings.getAVRModel(ctx, currentReceiver));
 		Logger.info("model is " + model.getClass().getName() + " area is "
 				+ area);
 
 		updateZoneState();
 
+	}
+
+	/**
+	 * Löst den Namen aus den Einstellungen per Reflection in die Modellklasse
+	 * auf: "AVR-3310" -> {@link AVR3310}, "ASD-51 (experimental)" ->
+	 * {@link ASD51}. Schlägt das fehl, gibt es nur einen Log-Eintrag und
+	 * {@link AVRGeneric}, der Anwender merkt davon nichts. Deshalb prüft
+	 * {@code ModelConfiguratorTest} alle Einträge aus
+	 * {@code @array/modelNames}.
+	 */
+	static IAVRModel createModel(String modelName) {
+		// "AVR-3310" -> "AVR3310"
+		final String am = modelName.replace("-", "").trim();
+		final String avrModel;
+		// "(experimental)" weg
+		int p = am.indexOf("(");
+		if (p != -1) {
+			avrModel = am.substring(0, p).trim();
+		} else {
+			avrModel = am;
+		}
+		if (avrModel.length() == 0) {
+			return new AVRGeneric();
+		}
+		try {
+			return (IAVRModel) Class.forName(
+					"de.pskiwi.avrremote.models." + avrModel).newInstance();
+		} catch (Exception x) {
+			Logger.error("create " + avrModel + " failed", x);
+			return new AVRGeneric();
+		}
 	}
 
 	private void updateZoneState() {

--- a/app/src/test/java/de/pskiwi/avrremote/models/ModelConfiguratorTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/models/ModelConfiguratorTest.java
@@ -91,7 +91,7 @@ public final class ModelConfiguratorTest {
 	@Test
 	public void unknownModelFallsBackToGenericWithoutFailing() {
 		assertEquals(AVRGeneric.class,
-				ModelConfigurator.createModel("AVR-4711").getClass());
+				ModelConfigurator.createModel("Kein-Solches-Modell").getClass());
 	}
 
 	/** "ASD-51 (experimental)" -> "ASD51" */
@@ -116,6 +116,10 @@ public final class ModelConfiguratorTest {
 					names.add(items.item(j).getTextContent().trim());
 				}
 				assertTrue("modelNames ist leer", !names.isEmpty());
+				// Ohne diese Prüfung wäre ein doppelter Eintrag grün: unten
+				// steht ein Set, und beide Kopien lösen ja auf
+				assertEquals("doppelter Eintrag in modelNames",
+						new TreeSet<String>(names).size(), names.size());
 				return names;
 			}
 		}

--- a/app/src/test/java/de/pskiwi/avrremote/models/ModelConfiguratorTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/models/ModelConfiguratorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Prüft die einzige Verbindung zwischen {@code @array/modelNames} in
+ * {@code res/values/lists.xml} und den Klassen in {@code models/}: sie besteht
+ * nur aus dem Klassennamen, den
+ * {@link ModelConfigurator#createModel(String)} per Reflection auflöst. Kein
+ * Compiler sieht, wenn eine der beiden Seiten umbenannt wird oder ein Eintrag
+ * fehlt - der Anwender bekommt dann still {@link AVRGeneric} und verliert alle
+ * Fähigkeiten seines Geräts.
+ */
+public final class ModelConfiguratorTest {
+
+	@Test
+	public void everyModelNameResolvesToItsOwnClass() throws Exception {
+		for (String modelName : readModelNames()) {
+			assertEquals("Auswahl \"" + modelName
+					+ "\" landet nicht in ihrer Modellklasse",
+					expectedClassName(modelName), ModelConfigurator
+							.createModel(modelName).getClass().getSimpleName());
+		}
+	}
+
+	/** Gegenrichtung: eine Modellklasse, die niemand auswählen kann. */
+	@Test
+	public void everyModelClassIsSelectable() throws Exception {
+		final Set<String> fromList = new TreeSet<String>();
+		for (String modelName : readModelNames()) {
+			fromList.add(expectedClassName(modelName));
+		}
+
+		final Set<String> onDisk = new TreeSet<String>();
+		for (File f : modelSources()) {
+			final String name = f.getName();
+			if (!name.endsWith(".java")) {
+				continue;
+			}
+			final String simpleName = name.substring(0, name.length()
+					- ".java".length());
+			final Class<?> c = Class.forName("de.pskiwi.avrremote.models."
+					+ simpleName);
+			// Interface und die beiden abstrakten Basisklassen fallen hier
+			// raus, ebenso die Infrastruktur (ModelArea, DynamicEQ*, ...)
+			if (IAVRModel.class.isAssignableFrom(c)
+					&& !Modifier.isAbstract(c.getModifiers())) {
+				onDisk.add(simpleName);
+			}
+		}
+
+		assertEquals("modelNames in lists.xml und models/ sind auseinander"
+				+ " gelaufen", onDisk, fromList);
+	}
+
+	/**
+	 * Hält fest, warum die Tests oben auf der Klasse bestehen und nicht nur
+	 * darauf, dass irgendein Modell herauskommt: der Fehlerfall ist stumm.
+	 */
+	@Test
+	public void unknownModelFallsBackToGenericWithoutFailing() {
+		assertEquals(AVRGeneric.class,
+				ModelConfigurator.createModel("AVR-4711").getClass());
+	}
+
+	/** "ASD-51 (experimental)" -> "ASD51" */
+	private static String expectedClassName(String modelName) {
+		final int p = modelName.indexOf('(');
+		final String withoutRemark = p == -1 ? modelName : modelName.substring(
+				0, p);
+		return withoutRemark.replace("-", "").trim();
+	}
+
+	private static List<String> readModelNames() throws Exception {
+		final Document doc = DocumentBuilderFactory.newInstance()
+				.newDocumentBuilder()
+				.parse(moduleFile("src/main/res/values/lists.xml"));
+		final NodeList arrays = doc.getElementsByTagName("string-array");
+		for (int i = 0; i < arrays.getLength(); i++) {
+			final Element array = (Element) arrays.item(i);
+			if ("modelNames".equals(array.getAttribute("name"))) {
+				final NodeList items = array.getElementsByTagName("item");
+				final List<String> names = new ArrayList<String>();
+				for (int j = 0; j < items.getLength(); j++) {
+					names.add(items.item(j).getTextContent().trim());
+				}
+				assertTrue("modelNames ist leer", !names.isEmpty());
+				return names;
+			}
+		}
+		throw new AssertionError("string-array modelNames fehlt in lists.xml");
+	}
+
+	private static File[] modelSources() {
+		final File[] files = moduleFile(
+				"src/main/java/de/pskiwi/avrremote/models").listFiles();
+		assertTrue("models/ ist nicht lesbar", files != null);
+		return files;
+	}
+
+	/** Der Test-Runner startet je nach Aufruf im Modul- oder im Wurzelordner. */
+	private static File moduleFile(String relativePath) {
+		File f = new File(relativePath);
+		if (!f.exists()) {
+			f = new File("app", relativePath);
+		}
+		assertTrue(relativePath + " nicht gefunden (cwd "
+				+ new File(".").getAbsolutePath() + ")", f.exists());
+		return f;
+	}
+}


### PR DESCRIPTION
Closes the *Test coverage is three files* item in TODO.md.

## Why

`ModelConfigurator` resolves the 60 receiver classes **by reflection** from the preference string (`"AVR-3310"` → `AVR3310`). That link is invisible to the compiler: rename a class, or let an entry in `@array/modelNames` drift, and the build stays green. At runtime it logs, falls back to `AVRGeneric`, and the user silently loses every capability of their receiver.

## What the test does

`models/ModelConfiguratorTest`, 3 cases:

- `everyModelNameResolvesToItsOwnClass` — each of the 60 entries must land in *its* class. The assertion compares the class name, because the failure mode is a silent fallback rather than an exception.
- `everyModelClassIsSelectable` — the other direction: every concrete `IAVRModel` in `models/` needs a list entry. The filter is `IAVRModel.isAssignableFrom` plus `!isAbstract`, not a hand-maintained exception list, so the filter cannot drift on its own.
- `unknownModelFallsBackToGenericWithoutFailing` — records *why* the two above have to assert on the class.

## Two supporting changes

- **`ModelConfigurator.createModel(String)`** — the normalisation (strip `-`, strip `(experimental)`, `Class.forName`) sat inside `update()` behind `AVRSettings` and a `Context`, unreachable from a JVM test. Moved into a package-visible static method that `update()` calls. Behaviour unchanged; without this the test would assert against a copy of the logic instead of the logic.
- **`lists.xml` declared as a test input** in `app/build.gradle`. Without it Gradle calls `testDebugUnitTest` up to date when only `lists.xml` changed — exactly the change the test exists to catch. This surfaced while verifying the failure case: the first run with a bent entry did not execute at all.

## Verification

Red before green: bending `AVR-3310` to `AVR-3315` in `lists.xml` fails both tests —

```
expected:<AVR[3315]> but was:<AVR[Generic]>
modelNames in lists.xml und models/ sind auseinander gelaufen  (set diff)
```

— and after the Gradle change it fails without `--rerun-tasks`. Reverted, `./gradlew build` green, 17 cases per variant.

No new dependencies; JUnit 4 and the JDK's own DOM parser only.

## Docs

TODO.md item ticked. CLAUDE.md test inventory updated (three → four classes, 13 → 17 cases) plus a note on the task-input pitfall. While counting, `Series08ParserTest` turned out to be listed there with 5 cases against an actual 6 — pre-existing, corrected in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEyp7H26qvZVSsb8Xq9euA