### PR TITLE
Clean up the on-screen display: orientation lock, row text size, and why R8 stays off

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -130,6 +130,21 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
       (`res/drawable/ic_launcher_foreground.xml`, `app/src/main/assets/icon.svg`, `docs/avr-icon.svg`
       and the store SVG).
 
+### Recommendations to decline
+
+The Console attaches "recommended actions" to every release. They are generic, they do not know what
+the app is, and they come back each time. Decided once, so they do not have to be re-argued:
+
+- **"Enable R8 to improve memory and performance" — no.** `ModelConfigurator.java:84` resolves the
+  60 receiver classes by name, `Class.forName("de.pskiwi.avrremote.models." + avrModel)`. They have
+  no static references, so shrinking removes all of them and every user silently falls back to
+  `AVRGeneric`, losing zones, quick-select, level controls and DAB. `ModelConfiguratorTest` does
+  **not** protect against this: it runs on the JVM against unminified classes, so the build stays
+  green and the damage only appears in the field. Turning it on would need
+  `-keep class de.pskiwi.avrremote.models.** { *; }` and verification on a device with a real model
+  selected — for close to nothing, because the app has no dependencies at all and the APK is 343 KB.
+  That is where R8 normally earns its keep. See also CLAUDE.md → *Receiver models*.
+
 ### Deadlines
 
 Everything below was checked in August 2026 and none of it is under our control, so re-read the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -137,13 +137,22 @@ the app is, and they come back each time. Decided once, so they do not have to b
 
 - **"Enable R8 to improve memory and performance" — no.** `ModelConfigurator.java:84` resolves the
   60 receiver classes by name, `Class.forName("de.pskiwi.avrremote.models." + avrModel)`. They have
-  no static references, so shrinking removes all of them and every user silently falls back to
-  `AVRGeneric`, losing zones, quick-select, level controls and DAB. `ModelConfiguratorTest` does
-  **not** protect against this: it runs on the JVM against unminified classes, so the build stays
-  green and the damage only appears in the field. Turning it on would need
-  `-keep class de.pskiwi.avrremote.models.** { *; }` and verification on a device with a real model
-  selected — for close to nothing, because the app has no dependencies at all and the APK is 343 KB.
-  That is where R8 normally earns its keep. See also CLAUDE.md → *Receiver models*.
+  no static references, so shrinking removes all of them and every user falls back to `AVRGeneric`.
+
+  What makes that bad is not that features disappear — it is that they do not. `AVRGeneric` extends
+  `AbstractModel`, which answers `true` to `hasZones()`, `hasQuick()` and `hasLevels()` and reports
+  `TYPE_7CH` levels, and `AVRGeneric.getZoneCount()` returns 3. So every receiver would be driven as
+  a generic 3-zone, 7-channel device with quick-select: a phantom zone on 2-zone models, a missing
+  one on 4-zone models, the generic input and surround lists instead of the model's own, and
+  quick-select offered where the hardware has none. Only `supportsDAB()` is an outright loss. The app
+  would look like it works and send the wrong commands.
+
+  `ModelConfiguratorTest` does **not** protect against this: it runs on the JVM against unminified
+  classes, so the build stays green and the damage only appears in the field. Turning R8 on would
+  need `-keep class de.pskiwi.avrremote.models.** { *; }` and verification on a device with a real
+  model selected — for close to nothing, because the app has no runtime dependencies and the APK is
+  343 KB. Shrinking libraries is where R8 normally earns its keep, and there are none. See also
+  CLAUDE.md → *Receiver models*.
 
 ### Deadlines
 

--- a/TODO.md
+++ b/TODO.md
@@ -158,16 +158,20 @@ blocks the current build, which is green.
 - [ ] Dead version check: `StatusbarManager.java:50` gates on `SDK_INT >= JELLY_BEAN`, always true
       at minSdk 24 (lint: `ObsoleteSdkInt`). The `if` wraps lines 51–74; the `Context`/`Intent`/
       `PendingIntent` setup above it stays.
-- [ ] **`ScreenInfo.isTablet()` calls anything over 4.5 inches a tablet** (`ScreenInfo.java:52`,
-      physical diagonal from `DisplayMetrics`). Reasonable in 2010; today every device that clears
-      minSdk 24 is well past it — a Pixel 8 measures about 6.2 — so the method now answers `true`
-      everywhere and no longer distinguishes anything. The orientation lock it used to guard is gone
-      (Play flagged it, and it had been unreachable for years), but one caller is left:
-      `ScreenListAdapter.java:140` picks text size 22 for "tablets", so every modern phone takes the
-      tablet branch and the `heightPixels` ladder below it is dead. Deciding what the app actually
-      wants here — smallest-width qualifiers rather than inches — is a UI question, not a rename.
-      Note `ScreenInfo` also feeds `FeedbackReporter.java:176`, where it is only logged, and that
-      `Display.getMetrics()` behind it has been deprecated since API 30.
+- [ ] **`ScreenInfo` measures the window, not the display.** The class builds its diagonal from
+      `getDefaultDisplay().getMetrics()` (`ScreenInfo.java:28-33`), and every caller hands it an
+      Activity — so in multi-window the numbers describe the activity's window, which is exactly why
+      the API was deprecated in API 30 in favour of `WindowMetrics.getBounds()`. Nothing depends on
+      the value any more: `isTablet()` and its 4.5-inch threshold are gone, and what is left only
+      reaches the OSD log line and `FeedbackReporter.java:169-176`. So this is a diagnostics-quality
+      item, not a behaviour one — but a feedback report from a split-screen session currently
+      overstates nothing and understates the device, which is worth knowing before trusting one.
+      For the record on that threshold: it was **not** unreachable, as the commit removing the
+      orientation lock claimed. Small phones above minSdk 24 exist — the Unihertz Jelly 2 is 3.0",
+      the Palm PVG100 3.3" — and on those the lock fired and `ScreenListAdapter`'s 12/15/21sp ladder
+      ran. Moving the size to `@dimen/osd_row_text_size` therefore does change something there:
+      those devices go to 22sp in a row whose height is fixed. Rare enough to accept, not rare
+      enough to have called impossible.
 
 ## Large, no deadline
 

--- a/TODO.md
+++ b/TODO.md
@@ -185,8 +185,14 @@ blocks the current build, which is green.
       at `:62`) without `takePersistableUriPermission()`, so it does not survive a restart. Note the
       fix is not just an added call: the picker uses `ACTION_PICK`, and persistable permissions need
       `ACTION_OPEN_DOCUMENT`. Part of the same Activity-Result-API rewrite.
-- [ ] `OnScreenDisplayActivity` was never exercised during the SDK 36 verification — reaching it
-      needs receiver display data. Worth a manual pass on a real receiver.
+- [x] `OnScreenDisplayActivity` was never exercised during the SDK 36 verification — reaching it
+      needs receiver display data. Done in August 2026 on a Pixel 8 (Android 17) against a real
+      receiver, with display lines actually populated: the list renders, the row text is the
+      expected size, and the screen rotates cleanly now that the portrait lock is gone — including
+      landscape, which falls back to the portrait layout because the OSD layouts have no
+      `layout-land` variant. Still unexercised there: the transport buttons and the search paths
+      (`btnPlay`/`btnPause`/`btnStop`, `screenMenu.doSearch()`), and the whole of `NetDisplay`'s
+      parsing beyond what that one receiver happened to send.
 
 ## Answered
 

--- a/TODO.md
+++ b/TODO.md
@@ -158,6 +158,16 @@ blocks the current build, which is green.
 - [ ] Dead version check: `StatusbarManager.java:50` gates on `SDK_INT >= JELLY_BEAN`, always true
       at minSdk 24 (lint: `ObsoleteSdkInt`). The `if` wraps lines 51–74; the `Context`/`Intent`/
       `PendingIntent` setup above it stays.
+- [ ] **`ScreenInfo.isTablet()` calls anything over 4.5 inches a tablet** (`ScreenInfo.java:52`,
+      physical diagonal from `DisplayMetrics`). Reasonable in 2010; today every device that clears
+      minSdk 24 is well past it — a Pixel 8 measures about 6.2 — so the method now answers `true`
+      everywhere and no longer distinguishes anything. The orientation lock it used to guard is gone
+      (Play flagged it, and it had been unreachable for years), but one caller is left:
+      `ScreenListAdapter.java:140` picks text size 22 for "tablets", so every modern phone takes the
+      tablet branch and the `heightPixels` ladder below it is dead. Deciding what the app actually
+      wants here — smallest-width qualifiers rather than inches — is a UI question, not a rename.
+      Note `ScreenInfo` also feeds `FeedbackReporter.java:176`, where it is only logged, and that
+      `Display.getMetrics()` behind it has been deprecated since API 30.
 
 ## Large, no deadline
 

--- a/app/src/main/java/de/pskiwi/avrremote/OnScreenDisplayActivity.java
+++ b/app/src/main/java/de/pskiwi/avrremote/OnScreenDisplayActivity.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import android.app.ListActivity;
-import android.content.pm.ActivityInfo;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.KeyEvent;
@@ -85,10 +84,6 @@ public final class OnScreenDisplayActivity extends ListActivity implements
 
 		final ScreenInfo screenInfo = new ScreenInfo(this);
 		Logger.info("create OSD " + screenInfo.toString());
-		if (!screenInfo.isTablet()) {
-			this
-					.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-		}
 
 		optionsMenu = new OptionsMenu(this, getApp().getModelConfigurator(),
 				this);

--- a/app/src/main/java/de/pskiwi/avrremote/ScreenInfo.java
+++ b/app/src/main/java/de/pskiwi/avrremote/ScreenInfo.java
@@ -49,16 +49,12 @@ public final class ScreenInfo {
 		return phyWidth;
 	}
 
-	public boolean isTablet() {
-		return getSquareWidth() > 4.5f;
-	}
-
 	@Override
 	public String toString() {
-		return "ScreenInfo sw:" + getSquareWidth() + " tablet:" + isTablet()
-				+ " xw:" + phyWidth + " yw:" + phyHeight + " xp/d:"
-				+ metrics.widthPixels + "/" + metrics.xdpi + "   yp/d:"
-				+ metrics.heightPixels + "/" + metrics.ydpi;
+		return "ScreenInfo sw:" + getSquareWidth() + " xw:" + phyWidth + " yw:"
+				+ phyHeight + " xp/d:" + metrics.widthPixels + "/"
+				+ metrics.xdpi + "   yp/d:" + metrics.heightPixels + "/"
+				+ metrics.ydpi;
 	}
 
 	private final Display display;

--- a/app/src/main/java/de/pskiwi/avrremote/ScreenListAdapter.java
+++ b/app/src/main/java/de/pskiwi/avrremote/ScreenListAdapter.java
@@ -18,7 +18,6 @@ package de.pskiwi.avrremote;
 
 import android.content.Context;
 import android.os.Handler;
-import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -133,24 +132,6 @@ public final class ScreenListAdapter extends BaseAdapter {
 		} else {
 			Logger.info("rowtext not found");
 		}
-		final DisplayMetrics displayMetrics = parentView.getResources()
-				.getDisplayMetrics();
-
-		final ScreenInfo screenInfo = new ScreenInfo(context);
-		if (screenInfo.isTablet()) {
-			tt.setTextSize(22);
-		} else {
-			if (displayMetrics.heightPixels < 800) {
-				if (displayMetrics.heightPixels < 480) {
-					tt.setTextSize(12);
-				} else {
-					tt.setTextSize(15);
-				}
-			} else {
-				tt.setTextSize(21);
-			}
-		}
-
 		return v;
 	}
 

--- a/app/src/main/res/layout/listrow.xml
+++ b/app/src/main/res/layout/listrow.xml
@@ -14,7 +14,7 @@
             android:layout_weight="1"
             android:id="@+id/rowtext"
             android:singleLine="true"
-            android:textSize="20dip"
+            android:textSize="@dimen/osd_row_text_size"
         	android:textStyle="bold"
             android:ellipsize="marquee"
         />

--- a/app/src/main/res/values-sw600dp/dimension.xml
+++ b/app/src/main/res/values-sw600dp/dimension.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Echte Tablets. Der Rest des Projekts qualifiziert noch mit "xlarge"
+         (values-xlarge/dimension.xml); sw600dp ist der Nachfolger und ab
+         minSdk 24 überall verfügbar. -->
+    <dimen name="osd_row_text_size">26sp</dimen>
+</resources>

--- a/app/src/main/res/values/dimension.xml
+++ b/app/src/main/res/values/dimension.xml
@@ -20,6 +20,10 @@
     
     <dimen name="osd_bottom_margin">100dip</dimen>
     <dimen name="neg_osd_bottom_margin">-100dip</dimen>
+
+    <!-- sp, nicht dip: die Zeile soll der Schriftgröße des Nutzers folgen.
+         Größer nur ab sw600dp, siehe values-sw600dp. -->
+    <dimen name="osd_row_text_size">22sp</dimen>
     
     <dimen name="button_corners">0dip</dimen>
     <dimen name="button_stroke">5dip</dimen>


### PR DESCRIPTION
Five commits, triggered by the two Play Console recommendations on release 125 (1.6.0). Everything
is confined to the OSD screen except the documentation.

**Verified on a Pixel 8 (Android 17) against a real receiver**, with display lines actually
populated: text size unchanged, rotation clean in both directions.

## 1. The portrait lock — removed

`OnScreenDisplayActivity.onCreate` held the only orientation restriction in the project:

```java
if (!screenInfo.isTablet()) {
    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
}
```

`ScreenInfo.isTablet()` is a physical diagonal over 4.5 inches — a 2010 heuristic that no mainstream
device has failed in over a decade. From Android 16 the restriction is ignored on large screens
regardless, and Play flagged the call.

**Correction, courtesy of review:** the first commit message calls this branch "unreachable on real
hardware for years". That is wrong. Small phones above `minSdk 24` exist — Unihertz Jelly 2 at 3.0",
Palm PVG100 at 3.3" — and on those the lock fired. It still deserved to go; the reason was
overstated. `fdf67cf` fixes the claim where it was durable (TODO.md).

The rotation it opens up was already wired: `onSaveInstanceState:237` stores the zone,
`onCreate:103` reads it back, no `configChanges` is declared, and `EdgeToEdge.apply(this)` follows
`setContentView`. Confirmed on the device.

## 2. Row text size — into dimension resources

`listrow.xml` has always declared `android:textSize`, but `ScreenListAdapter` overwrote it on every
bind, so the resource never applied:

```java
if (screenInfo.isTablet()) { tt.setTextSize(22); }
else { ... 12 / 15 / 21 by heightPixels ... }
```

Now `@dimen/osd_row_text_size`: **22sp** by default and **26sp from `sw600dp`** for real tablets.
Verified in the APK: `() 22sp`, `(sw600dp) 26sp`. The declared value was also wrong in its own way —
`20dip` rather than `sp`, so it would not have followed the user's font scale had it ever applied.

For mainstream hardware this is behaviour-neutral, since 22sp is what those devices already had. On
the sub-4.5-inch phones above it is not: they ran the ladder and go from 12 or 15sp to 22sp in a
fixed-height row. Rare enough to accept, and now written down rather than implied.

Dropping the block also removes a `new ScreenInfo(context)` per row per bind — a `WindowManager`
lookup and a `DisplayMetrics` allocation — on a list that refreshes every 100 ms.

`isTablet()` then had no callers and is gone, with the `tablet:` it contributed to
`ScreenInfo.toString()`.

## 3. R8 — declined, and recorded in RELEASE.md

`ModelConfigurator.java:84` resolves the 60 receiver classes by name, so shrinking strips them and
every user falls back to `AVRGeneric`.

**Correction, courtesy of review:** the first version of this section said that loses zones,
quick-select, levels and DAB. Checked against `AbstractModel`, it is backwards. `AVRGeneric`
inherits `hasZones()`, `hasQuick()` and `hasLevels()` as `true`, `TYPE_7CH` levels and
`getZoneCount()` 3 — so the features stay and turn *wrong*: a phantom zone on 2-zone models, one
missing on 4-zone models, generic input and surround lists, quick-select where the hardware has
none. Only DAB is an outright loss. The app would look like it works and send the wrong commands,
which is the stronger argument for leaving R8 off.

Nothing catches it either: `ModelConfiguratorTest` runs on the JVM against unminified classes, so
the build stays green and the breakage only reaches users.

## 4. TODO.md

`OnScreenDisplayActivity` is ticked — the SDK 36 pass could never open it, this one did. Narrowed
rather than dropped: the transport buttons and both search paths were not exercised, and
`NetDisplay` only saw what one receiver sent.

The `ScreenInfo` entry is rewritten. What is actually left is that it builds its diagonal from an
Activity-scoped `getDefaultDisplay().getMetrics()`, so in multi-window it measures the window rather
than the device — which is why that API was deprecated in API 30. Nothing reads the value now, so it
only affects how far a feedback report can be trusted.

## Verification

`./gradlew build` green, 17 unit tests pass. Lint 295 → 293: `SourceLockedOrientationActivity` 1 → 0,
`SpUsage` 1 → 0, nothing new. No `setRequestedOrientation`, `screenOrientation`, `resizeableActivity`,
`ActivityInfo` or `isTablet` left in the source.

**The `sw600dp` bucket is verified too**, on an `android-36` emulator configured as a tablet
(2560x1600 @ 320dpi, which reports `sw800dp`). Since the OSD needs a receiver to populate, the row
was rendered through a throwaway activity that inflates `listrow.xml` with sample text; it lived in
a temporary git worktree, never entered the repository and is gone.

At default font scale the TextView reports **52px = 26.0sp** — the `sw600dp` value resolved on a
real device, not just in `aapt2 dump`. At the maximum system font scale (200%) it reports **73px**,
not the 104px a naive doubling would give: Android 14+ scales large text non-linearly, so the very
case that looked risky is the one the platform already damps. `listPreferredItemHeight` is 128px
against a text box of 128 - 24 = 104px, so there is headroom at both scales, and the screenshots
show no clipping on any row.

Worth noting the phone side needs no such check: 22sp is exactly what every device already got from
the Java branch, so no font scale can regress there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEyp7H26qvZVSsb8Xq9euA
