### PR TITLE
Drop the JELLY_BEAN guard around the notification

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -155,9 +155,19 @@ blocks the current build, which is green.
       is inside the default full-backup scope, the old shared-external `AVRRemote/` was not, so with
       logging enabled the log files and `avrremote.zip` — which contain the same receiver IPs, via
       `AVRSettings.getAll()` — now travel with the backup too.
-- [ ] Dead version check: `StatusbarManager.java:50` gates on `SDK_INT >= JELLY_BEAN`, always true
-      at minSdk 24 (lint: `ObsoleteSdkInt`). The `if` wraps lines 51–74; the `Context`/`Intent`/
-      `PendingIntent` setup above it stays.
+- [x] Dead version check in `StatusbarManager.updateNotification()`: a `SDK_INT >= JELLY_BEAN`
+      gate, always true at minSdk 24 (lint: `ObsoleteSdkInt`). Removed, and worth recording why it
+      was more than clutter — the `if` had no `else`, so had it ever been false the method would
+      have posted no notification at all and said nothing. The inner `>= O` check stays; API 26 is
+      above minSdk, so the notification channel really is conditional. Lint's remaining
+      `ObsoleteSdkInt` is `res/values-v14`, a folder qualifier rather than a version check, and is
+      the item above.
+- [ ] Two things noticed in `StatusbarManager` while doing that, both pre-existing and both left
+      alone: the field `private Notification notification;` is never read or written — the only
+      notification in play is the local in `updateNotification()` — and `createNotificationChannel`
+      runs on every call rather than once. The latter is harmless (creating an existing channel id
+      only updates the name; importance can only be lowered and the sound is ignored after
+      creation), but it belongs in `AVRApplication.onCreate`.
 
 ## Large, no deadline
 

--- a/app/src/main/java/de/pskiwi/avrremote/StatusbarManager.java
+++ b/app/src/main/java/de/pskiwi/avrremote/StatusbarManager.java
@@ -45,6 +45,7 @@ public final class StatusbarManager {
 		PendingIntent contentIntent = PendingIntent.getActivity(app, 0,
 				notificationIntent, PendingIntent.FLAG_IMMUTABLE);
 
+		// https://developer.android.com/guide/topics/ui/notifiers/notifications.html
 		Notification.Builder builder = new Notification.Builder(context);
 
 		builder.setAutoCancel(false);

--- a/app/src/main/java/de/pskiwi/avrremote/StatusbarManager.java
+++ b/app/src/main/java/de/pskiwi/avrremote/StatusbarManager.java
@@ -45,34 +45,30 @@ public final class StatusbarManager {
 		PendingIntent contentIntent = PendingIntent.getActivity(app, 0,
 				notificationIntent, PendingIntent.FLAG_IMMUTABLE);
 
-        // https://stackoverflow.com/questions/32345768/cannot-resolve-method-setlatesteventinfo
-		// https://developer.android.com/guide/topics/ui/notifiers/notifications.html
-		if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-			Notification.Builder builder = new Notification.Builder(context);
+		Notification.Builder builder = new Notification.Builder(context);
 
-			builder.setAutoCancel(false);
-			builder.setContentIntent(contentIntent);
-			builder.setContentTitle(contentTitle);
-			builder.setContentText(contentText);
-			builder.setSmallIcon(R.drawable.ic_stat_avr);
-			builder.setOngoing(true);
+		builder.setAutoCancel(false);
+		builder.setContentIntent(contentIntent);
+		builder.setContentTitle(contentTitle);
+		builder.setContentText(contentText);
+		builder.setSmallIcon(R.drawable.ic_stat_avr);
+		builder.setOngoing(true);
 
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-			{
-				String channelId = "avr_remote_channel";
-				NotificationChannel channel = new NotificationChannel(
-						channelId,
-						"AVR-Remote",
-						NotificationManager.IMPORTANCE_DEFAULT);
-				channel.setSound(null, null);
-				notificationManager.createNotificationChannel(channel);
-				builder.setChannelId(channelId);
-			}
-
-			Notification notification=builder.build();
-
-			notificationManager.notify(NOTIFICATION_ID,notification);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+		{
+			String channelId = "avr_remote_channel";
+			NotificationChannel channel = new NotificationChannel(
+					channelId,
+					"AVR-Remote",
+					NotificationManager.IMPORTANCE_DEFAULT);
+			channel.setSound(null, null);
+			notificationManager.createNotificationChannel(channel);
+			builder.setChannelId(channelId);
 		}
+
+		Notification notification=builder.build();
+
+		notificationManager.notify(NOTIFICATION_ID,notification);
 	}
 
 	public void update() {


### PR DESCRIPTION
Closes the *Dead version check* item in TODO.md. Two commits: the change, and the corrections a
review turned up.

`android.os.Build.VERSION.SDK_INT >= JELLY_BEAN` (API 16) has been true for every device the app
runs on since `minSdk` went to 24 — lint flags it as `ObsoleteSdkInt`.

Worth noting what the branch did when false: **nothing at all.** There was no `else`, so
`updateNotification()` would have silently posted no notification. The guard was a dead
silent-failure path, not merely dead code.

**The inner check stays.** `Build.VERSION_CODES.O` is API 26, above `minSdk 24`, so the notification
channel really is conditional. A grep over the rest of the project finds only two more `SDK_INT`
checks, both legitimate: `AVRSettings.java:116` (TIRAMISU, 33) and `EdgeToEdge.java:38` (R, 30).

## From the review

- **The TODO checkbox was not ticked**, contrary to the convention in CLAUDE.md — and its line
  references had gone stale in the process: after the change, `StatusbarManager.java:50` is
  `setAutoCancel` and "lines 51–74" describe nothing. Ticked and rewritten.
- **Only one of the two deleted comments was vestigial.** The `setLatestEventInfo` link explained
  the pre-JELLY_BEAN alternative — a method the platform removed at API 23 — so it goes. The
  notifications guide documents the `Notification.Builder` code that is still there, so it is back.
- **Two pre-existing problems noted in TODO.md rather than fixed here**, per the convention on
  unrelated dead code: the field `private Notification notification;` is never read or written, and
  `createNotificationChannel` runs on every call instead of once. The latter is harmless — creating
  an existing channel id only updates the name, importance can only be lowered, sound is ignored
  after creation — but it belongs in `AVRApplication.onCreate`.

## Verification

`./gradlew clean assembleDebug lintDebug` green, lint re-run from clean rather than read from a
stale report. Lint compared issue-by-issue against `master`: **every category identical except
`ObsoleteSdkInt`, 2 → 1.** The survivor is `res/values-v14`, a folder qualifier below `minSdk`
rather than a version check, and its own TODO item. `StatusbarManager.java` no longer appears at
all.

API 24/25 was not exercised by anyone, but the code there is byte-identical in behaviour to
`master`'s — the outer guard was true on those levels too — and `new Notification.Builder(Context)`
is the correct, non-deprecated API below O. On API 26+ `setChannelId` runs before `build()`, so
`notify()` cannot hit *No Channel found*.

**Verified on a Pixel 8 (Android 17):** the ongoing notification appears, survives a restart, and
opens the app when tapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEyp7H26qvZVSsb8Xq9euA