### PR TITLE
Do not tear down a connection that resume just rebuilt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -94,17 +94,19 @@ blocks the current build, which is green.
       report we have a log for was *not* this — the process had survived; it was the stale-teardown
       race in the item below.
 - [ ] `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()` →
-      `threadHandler.join()` (`core/ResilentConnector.java:244`, unbounded — see also the `join(1000)`
-      at `:50`) runs on the UI thread, so a slow `checkAddress()`/`connect()` in the old thread can
-      block resume long enough to ANR. Flagged in PR #13 review, predates that PR. The second race
-      listed there — a teardown deferred by Doze firing just after resume and stopping the
-      connection `contextResumed()` had just rebuilt — is fixed, see below.
+      `threadHandler.join()` (`core/ResilentConnector.java:244`) runs on the UI thread. Bounded at
+      roughly a second by the `join(1000)` at `:50` plus the `closeCurrentConnection()` in the
+      `finally`, but that is still enough to ANR when a slow `checkAddress()`/`connect()` in the old
+      thread holds it up. Flagged in PR #13 review, predates that PR. The second race listed there —
+      a teardown deferred by Doze firing just after resume and stopping the connection
+      `contextResumed()` had just rebuilt — is fixed, see below.
 - [x] Teardown deferred by Doze stops the connection right after resume, leaving no reconnect loop
-      at all until the app is killed and restarted. Both delivery paths are closed: the
-      `ACTION_SCREEN_OFF` receiver in `AVRApplication` is gone (`ActiveHandler` is now the only
-      owner of the disconnect policy, so the connection drops after the user's auto-disconnect
-      timeout instead of immediately on screen-off), and `StopConnectorTask.run()` skips the stop
-      when an activity is active again — `cancelCurrentTask()` only wins that race sometimes.
+      at all until the app is killed and restarted. The `ACTION_SCREEN_OFF` receiver in
+      `AVRApplication` is gone — `ActiveHandler` is now the only owner of the disconnect policy, so
+      the connection drops after the user's auto-disconnect timeout instead of immediately on
+      screen-off. On the timer path `StopConnectorTask.run()` skips the stop when an activity is
+      active again (`cancelCurrentTask()` only wins that race sometimes) and, because that check is
+      not atomic against a resume landing right after it, reconnects itself if one did.
 
 ## Time bomb, no fuse length known
 

--- a/TODO.md
+++ b/TODO.md
@@ -90,17 +90,21 @@ blocks the current build, which is green.
       during the Apache removal — decide whether the feature was meant to be wired up or should go.
 - [ ] **The receiver connection lives on a daemon thread owned by `AVRApplication`, not a Service.**
       A design decision from 2010. Under modern background restrictions the process can be reclaimed
-      and the connection dies with it. This is the most likely cause of "the app just stops
-      responding" reports.
-- [ ] Two races in the resume path, flagged in PR #13 review, not fixed there because both predate
-      that PR and are independent of its Doze-detection change:
-      `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()` →
-      `threadHandler.join()` (`core/ResilentConnector.java:241`, unbounded — see also the `join(1000)`
-      at `:47`) runs on the UI thread, so a slow `checkAddress()`/`connect()` in the old thread can
-      block resume long enough to ANR. Separately, `java.util.Timer` catches up on missed ticks once
-      the process thaws, so a `StopConnectorTask` deferred by Doze (`ActiveHandler.java`'s
-      `StopConnectorTask.run()`) can fire just after resume and stop a connection
-      `contextResumed()` just rebuilt; `cancelCurrentTask()` only helps if it wins that race.
+      and the connection dies with it. Note that the one "app does not reconnect after standby"
+      report we have a log for was *not* this — the process had survived; it was the stale-teardown
+      race in the item below.
+- [ ] `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()` →
+      `threadHandler.join()` (`core/ResilentConnector.java:244`, unbounded — see also the `join(1000)`
+      at `:50`) runs on the UI thread, so a slow `checkAddress()`/`connect()` in the old thread can
+      block resume long enough to ANR. Flagged in PR #13 review, predates that PR. The second race
+      listed there — a teardown deferred by Doze firing just after resume and stopping the
+      connection `contextResumed()` had just rebuilt — is fixed, see below.
+- [x] Teardown deferred by Doze stops the connection right after resume, leaving no reconnect loop
+      at all until the app is killed and restarted. Both delivery paths are closed: the
+      `ACTION_SCREEN_OFF` receiver in `AVRApplication` is gone (`ActiveHandler` is now the only
+      owner of the disconnect policy, so the connection drops after the user's auto-disconnect
+      timeout instead of immediately on screen-off), and `StopConnectorTask.run()` skips the stop
+      when an activity is active again — `cancelCurrentTask()` only wins that race sometimes.
 
 ## Time bomb, no fuse length known
 

--- a/TODO.md
+++ b/TODO.md
@@ -94,8 +94,8 @@ blocks the current build, which is green.
       report we have a log for was *not* this — the process had survived; it was the stale-teardown
       race in the item below.
 - [ ] `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()` →
-      `threadHandler.join()` (`core/ResilentConnector.java:244`) runs on the UI thread. Bounded at
-      roughly a second by the `join(1000)` at `:50` plus the `closeCurrentConnection()` in the
+      `threadHandler.join()` (`core/ResilentConnector.java:250`) runs on the UI thread. Bounded at
+      roughly a second by the `join(1000)` at `:56` plus the `closeCurrentConnection()` in the
       `finally`, but that is still enough to ANR when a slow `checkAddress()`/`connect()` in the old
       thread holds it up. Flagged in PR #13 review, predates that PR. The second race listed there —
       a teardown deferred by Doze firing just after resume and stopping the connection

--- a/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
@@ -83,16 +83,6 @@ public final class AVRApplication extends Application {
 		private boolean connected;
 	};
 
-	private final BroadcastReceiver standByEventReceiver = new BroadcastReceiver() {
-
-		@Override
-		public void onReceive(Context context, Intent intent) {
-			Logger.info("System StandBy ...");
-			connector.stop();
-		}
-
-	};
-
 	@Override
 	public void onCreate() {
 		super.onCreate();
@@ -163,10 +153,6 @@ public final class AVRApplication extends Application {
 		filter.addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION);
 		filter.addAction(WifiManager.WIFI_STATE_CHANGED_ACTION);
 		registerReceiver(wifiEventReceiver, filter);
-
-		IntentFilter standbyFilter = new IntentFilter();
-		standbyFilter.addAction(Intent.ACTION_SCREEN_OFF);
-		registerReceiver(standByEventReceiver, standbyFilter);
 
 		statusbarManager = new StatusbarManager(this);
 

--- a/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
+++ b/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
@@ -31,6 +31,15 @@ public final class ActiveHandler {
 		@Override
 		public void run() {
 			Logger.info("run stopConnectorRunnable");
+			// Der Task kann durch Doze/App-Standby beliebig verzoegert werden
+			// und dann erst feuern, wenn laengst wieder eine Activity im
+			// Vordergrund ist - und wuerde die Verbindung abraeumen, die
+			// contextResumed() gerade aufgebaut hat. cancelCurrentTask()
+			// gewinnt dieses Rennen nur manchmal.
+			if (isActive()) {
+				Logger.info("stopConnectorRunnable: activity active -> skip");
+				return;
+			}
 			connector.stop();
 		}
 	}
@@ -103,7 +112,8 @@ public final class ActiveHandler {
 	private TimerTask task;
 	// -1 = kein Pause-Zeitpunkt gemerkt (z.B. allererstes contextResumed())
 	private long pausedAtElapsedRealtime = -1;
-	private Context activeContext;
+	// volatile: wird vom Timer-Thread in StopConnectorTask gelesen
+	private volatile Context activeContext;
 	private final Timer timer = new Timer("StopConnector-Timer", true);
 	private final ResilentConnector connector;
 }

--- a/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
+++ b/app/src/main/java/de/pskiwi/avrremote/ActiveHandler.java
@@ -41,6 +41,14 @@ public final class ActiveHandler {
 				return;
 			}
 			connector.stop();
+			// Die Wache oben ist kein atomares Check-then-Act: genau zwischen
+			// ihr und dem stop() kann ein contextResumed() gelaufen sein, dessen
+			// frisch gestarteten Reconnect-Thread stop() gerade entwertet hat.
+			// Dann selbst heilen, sonst bleibt gar kein Reconnect-Loop uebrig.
+			if (isActive()) {
+				Logger.info("stopConnectorRunnable: resume won the race -> reconnect");
+				connector.forceReconnect();
+			}
 		}
 	}
 
@@ -50,15 +58,23 @@ public final class ActiveHandler {
 
 	public void contextResumed(Context context) {
 		Logger.info("ActiveHandler.activity resumed " + context);
+		// vor cancelCurrentTask(): ein StopConnectorTask, der jetzt gerade
+		// laeuft, sieht so auf jeden Fall isActive()
 		activeContext = context;
 		// "task != null" allein reicht nicht: der Timer kann durch Doze/App-
 		// Standby beliebig verzoegert werden, auch weit ueber disconnectTimeout
 		// hinaus, ohne dass StopConnectorTask je gefeuert hat. Stattdessen die
 		// tatsaechlich vergangene Zeit seit contextPaused() gegen den Timeout
-		// pruefen.
+		// pruefen. Gedeckelt, weil der Timeout bis zu 2h betragen darf, das
+		// "isRunning()" unten aber nur Sekunden lang etwas wert ist: es haengt
+		// an Socket.isConnected(), und das bleibt nach einem einmal geglueckten
+		// Connect fuer immer true - auch bei einem Socket, den Doze laengst
+		// gekappt hat. Der Shortcut ist fuer Rotation, Dialoge und Tab-Wechsel
+		// gedacht.
+		final long quickReturnTimeout = Math.min(
+				AVRSettings.getDisconnectTimeout(context), MAX_QUICK_RETURN_SEC) * 1000L;
 		final boolean quickReturn = pausedAtElapsedRealtime >= 0
-				&& SystemClock.elapsedRealtime() - pausedAtElapsedRealtime < AVRSettings
-						.getDisconnectTimeout(context) * 1000L;
+				&& SystemClock.elapsedRealtime() - pausedAtElapsedRealtime < quickReturnTimeout;
 		pausedAtElapsedRealtime = -1;
 		cancelCurrentTask();
 		if (quickReturn) {
@@ -116,4 +132,6 @@ public final class ActiveHandler {
 	private volatile Context activeContext;
 	private final Timer timer = new Timer("StopConnector-Timer", true);
 	private final ResilentConnector connector;
+	// so lange darf contextResumed() der bestehenden Verbindung glauben
+	private static final int MAX_QUICK_RETURN_SEC = 60;
 }

--- a/app/src/main/java/de/pskiwi/avrremote/core/ResilentConnector.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/ResilentConnector.java
@@ -33,8 +33,14 @@ public final class ResilentConnector implements ISender {
 	// Verwaltung des Verbindungsthreads
 	private final static class ThreadHandler {
 
+		// isAlive(), nicht nur "!= null": ein gestorbener Thread wuerde
+		// reconfigure() sonst glauben machen, es laufe noch ein Reconnect-Loop,
+		// und der Kurzschluss dort startet dann nie einen neuen. Aktuell kann
+		// das nicht passieren - join() nullt thread im finally - aber die
+		// Fehlerklasse ist genau die, die den Reconnect schon einmal
+		// stillschweigend beerdigt hat.
 		public synchronized boolean isDefined() {
-			return thread != null;
+			return thread != null && thread.isAlive();
 		}
 
 		public synchronized void join() {

--- a/app/src/main/java/de/pskiwi/avrremote/core/ResilentConnector.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/ResilentConnector.java
@@ -42,8 +42,11 @@ public final class ResilentConnector implements ISender {
 				Logger.info("stop connector");
 				thread.interrupt();
 				try {
-					// 1000 wg. ANR Broadcast of Intent {
-					// act=android.intent.action.SCREEN_OFF
+					// Begrenzt warten: join() laeuft ueber forceReconnect()
+					// auf dem UI-Thread, und ein Thread in einem nicht
+					// unterbrechbaren Connect/Ping wuerde ihn sonst bis zum
+					// ANR blockieren. Der "Zombie" ist ueber generation
+					// bereits entwertet und kann nichts mehr publizieren.
 					thread.join(1000);
 				} catch (InterruptedException e) {
 					Logger.error("Reconnector:join failed", e);


### PR DESCRIPTION
## Problem

Nach einer Weile im Standby kam die App beim Öffnen ohne Verbindung hoch und blieb so, bis sie beendet und neu gestartet wurde. Der Log eines Users belegt den Ablauf:

```
18:27:27  activity paused                 Bildschirm aus
18:27:37  run stopConnectorRunnable       Auto-Disconnect nach 10 s
          ~20 Min Doze, Prozess eingefroren
18:48:07  activity resumed -> forceReconnect
18:48:07  Reconnector:start new connector      generation = N
18:48:07  System StandBy ...                   SCREEN_OFF von 18:27, jetzt zugestellt
18:48:07  stop connector                       generation = N+1
18:48:07  Reconnector:connector stopped        neuer Thread sieht !isCurrent()
          danach nichts mehr
```

Android hatte den `SCREEN_OFF`-Broadcast für den eingefrorenen Prozess in die Warteschlange gelegt und 49 ms **nach** `onResume` ausgeliefert. `standByEventReceiver` rief bedingungslos `connector.stop()` und entwertete damit über `generation.incrementAndGet()` genau den Reconnect-Thread, den `forceReconnect()` einen Wimpernschlag vorher gestartet hatte. Danach gibt es keinen Rückweg — ein weiteres `contextResumed()` kommt nicht mehr, die Activity *ist* ja resumed, und ein Reconnect-Loop existiert nicht mehr.

Das ist **nicht** das TODO-Item „Verbindung lebt auf einem Daemon-Thread statt in einem Service": der Prozess hat überlebt, `openend at` steht im Log nur bei 18:24:15 und dann erst wieder beim manuellen Neustart um 18:48:40.

## Änderung

- **`AVRApplication`**: `standByEventReceiver` samt Registrierung entfernt. `ActiveHandler` ist jetzt alleiniger Besitzer der Trennlogik — Bildschirm-aus pausiert die Activity ohnehin, und genau das plant den Stopp. Folge: getrennt wird nach dem eingestellten Auto-Disconnect-Timeout statt sofort bei Bildschirm-aus.
- **`ActiveHandler`**: derselbe Fehler über den Timer-Pfad (in `TODO.md` bereits beschrieben) ist mit geschlossen — `StopConnectorTask.run()` verwirft den Stopp, solange eine Activity aktiv ist. `cancelCurrentTask()` in `contextResumed()` gewinnt das Rennen nur manchmal. `activeContext` wird `volatile`, weil der Timer-Thread es liest.
- **`ResilentConnector`**: Kommentar am `join(1000)` richtiggestellt — er begründete das Timeout mit dem jetzt entfernten Broadcast. Das Timeout bleibt, aus seinem echten Grund: `join()` läuft über `forceReconnect()` auf dem UI-Thread.
- **`TODO.md`**: Item abgehakt, der weiterhin offene ANR-Teil als eigener Punkt stehen geblieben.

## Test

`./gradlew build` grün (die 17 JVM-Tests decken davon nichts ab). **Auf Gerät nicht verifiziert** — hier hing keins dran.

Zum Nachstellen: Verbindung aufbauen, Logging an, Bildschirm aus, `adb shell dumpsys deviceidle force-idle`, einige Minuten warten, `unforce`, aufwecken, App öffnen. Erwartet: `activity resumed` → `forceReconnect` → `connection to [...] established`, und kein `stop connector` danach. Gegenprobe, dass der Normalpfad noch trennt: App im Vordergrund, Bildschirm aus, Timeout abwarten → `run stopConnectorRunnable` → `stop connector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9yDPoKDmCwL971LAYKbTr