### PR TITLE
Move the connection and Doze knowledge into CONNECTION.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,13 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
-**There is almost no test coverage.** `src/test` holds six JVM test classes —
-`http/HTTPSupportTest` (7 cases), `http/Series08ParserTest` (6), `core/ThreadHandlerTest` (5),
-`models/ModelConfiguratorTest` (3), `ReceiverStatusTest` (3) and `http/AVRXMLInfoParserTest` (1),
-JUnit 4 being the only dependency in the project — and there is no `src/androidTest` at all.
-`./gradlew test` runs those twenty-five cases and nothing else (twice, in fact: once per build
-variant), so do not report a change as verified because the build passed; verify on a device or
-emulator instead. Four limits are worth knowing before writing more tests:
+**There is almost no test coverage.** `src/test` holds six JVM test classes on JUnit 4, the only
+dependency in the project — `http/HTTPSupportTest`, `http/Series08ParserTest`,
+`core/ThreadHandlerTest`, `models/ModelConfiguratorTest`, `ReceiverStatusTest` and
+`http/AVRXMLInfoParserTest` — and there is no `src/androidTest` at all. `./gradlew test` runs a few
+dozen cases and nothing else (twice, in fact: once per build variant), so do not report a change as
+verified because the build passed; verify on a device or emulator instead. Four limits are worth
+knowing before writing more tests:
 
 - These run on the desktop JVM, not on Android's OkHttp-backed stack. Anything Android-specific —
   the implicit `Accept-Encoding: gzip`, chunked request bodies — cannot be pinned here, only
@@ -63,17 +63,14 @@ emulator instead. Four limits are worth knowing before writing more tests:
   resolves its paths against both the module and the root directory, because the working directory
   depends on how the run was started.
 - `core/ThreadHandlerTest` asserts on wall-clock time, as does `Series08ParserTest`'s
-  `largeLineStaysFast`: it pins that tearing the reconnect thread down does not block its caller,
-  which is the UI thread via
-  `ActiveHandler.contextResumed()` → `forceReconnect()`. The threshold sits between "no wait" and
-  the `join(1000)` it replaced (measured 1003 ms), so keep that margin if you touch it. It reaches
+  `largeLineStaysFast`. Its threshold sits between "no wait" and the `join(1000)` it replaced
+  (measured 1003 ms), so keep that margin if you touch it. It reaches
   `ResilentConnector.ThreadHandler` because that nested class is package-private for exactly this
   reason — the enclosing class cannot be built from a JVM test at all, because its constructor wants
   an `EnableManager` and that one builds a `Handler` in a field initialiser. Same trick as
-  `ModelConfigurator.createModel(String)`. Note what
-  it does *not* cover: that a detached thread publishes nothing after `stop()` returns. That is the
-  load-bearing half of the argument, it lives in `Reconnector.run()`'s `isCurrent()` checks and
-  `publishConnector()`, and no JVM test reaches it — read those before touching either.
+  `ModelConfigurator.createModel(String)`. What it does *not* cover is the load-bearing half of the
+  argument — that a detached thread publishes nothing after `stop()` returns — and no JVM test
+  reaches that; see [CONNECTION.md](CONNECTION.md) → *The generation counter*.
 
 **A log a user sent in** (`log/SDLogger` writes it, `log/FeedbackReporter` mails it) has one
 header line per entry and carries a `#seq` and a thread name. Sort by `#seq`, never by timestamp
@@ -87,27 +84,14 @@ Release builds are only signed when a keystore is configured; otherwise the buil
 an unusable `app-release-unsigned.apk`. Conditions and setup: [RELEASE.md](RELEASE.md).
 
 Debug builds show a greyed-out line with branch, short commit hash and commit time above the status
-bar (`R.id.textBuildInfo` in `tabhost.xml`, switched visible in `AVRRemote.onCreate`). The value comes
-from `BuildConfig.BUILD_INFO`, which `app/build.gradle` fills by calling `git` at configuration time —
-**only in the `debug` build type**; `defaultConfig` sets it to the empty string and that is what
-release keeps, which is what makes the line disappear there. Commit time, not build time, so the field
-stays stable between builds of the same commit; a `+` after the hash means the working tree was dirty.
-Three things there are deliberate:
-
-- `providers.exec`, not `ProcessBuilder`. Starting a process directly makes the configuration
-  incompatible with the configuration cache — the build then *aborts* with "external process started"
-  the moment anyone passes `--configuration-cache`, rather than degrading. Note the exec spec takes no
-  `errorOutput`: a value source rejects an arbitrary stream and the whole provider fails to be created,
-  which silently empties `BUILD_INFO`. Gradle discards the stderr anyway.
-- On detached HEAD only `GITHUB_REF_NAME` is consulted, and the branch is left out entirely when that
-  is unset. `git name-rev` would fill it, but with whatever ref happens to reach the commit —
-  `tags/v1.0~1` (a *different* commit, and the `~1` is then stripped by the charset filter), a foreign
-  branch, or `undefined`. No branch beats a wrong one.
-- The value is filtered to `[A-Za-z0-9._/+: -]` because it is pasted into generated Java source. Keep
-  the `-` last in that character class.
-
-Every `git` call falls back to an empty string (no git binary, no repo, git failing for any reason),
-and an empty `BUILD_INFO` just means no line — the build must never fail over this.
+bar (`R.id.textBuildInfo` in `tabhost.xml`, switched visible in `AVRRemote.onCreate`), fed from
+`BuildConfig.BUILD_INFO`. **The `buildInfo` block at the top of `app/build.gradle` explains
+itself** in its comments — why `providers.exec` rather
+than `ProcessBuilder`, why a detached HEAD falls back to `GITHUB_REF_NAME` instead of `git name-rev`,
+why the value is charset-filtered, and why no `git` failure may break the build. Read the comments
+there before changing any of it. One thing not said there: the exec spec deliberately takes no
+`errorOutput`, because a value source rejects an arbitrary stream and the whole provider then fails
+to be created, silently emptying `BUILD_INFO`.
 
 ## Architecture
 
@@ -142,9 +126,8 @@ The flags and their cascade: [CONNECTION.md](CONNECTION.md).
 `IStateFilter` decides which screen currently receives state updates, so background activities do not
 fight over the display listener.
 
-`core/display/` parses the receiver's on-screen display into `DisplayLine`s. `NetDisplay` (1182
-lines), `TunerDisplay` (1059) and `BDDisplay` (393) are three separate parsers for different input
-types.
+`core/display/` parses the receiver's on-screen display into `DisplayLine`s. `NetDisplay`,
+`TunerDisplay` and `BDDisplay` are three separate, large parsers for different input types.
 
 Up to 4 zones and up to 3 receivers are supported; the receiver index threads through
 `AVRSettings.getAVRModel(ctx, receiverNr)` and the `receiverSuffix()` preference-key convention.
@@ -152,11 +135,10 @@ Up to 4 zones and up to 3 receivers are supported; the receiver index threads th
 ### Receiver models — reflection registry
 
 `models/` holds **60 receiver classes**, one per receiver family, each overriding capability
-predicates (`hasZones()`, `hasQuick()`, `getSupportedLevels()`, `supportsDAB()`, …). The directory
-has 67 `.java` files — the other seven are infrastructure: `AbstractModel`, `AbstractMarantzAV`,
-`IAVRModel`, `ModelArea`, `ModelConfigurator` and the two `DynamicEQ*` enums. All 60 reach
-`AbstractModel`, but only 33 extend it directly; the rest go through `AbstractMarantzAV` or another
-model class (`AVR990 extends AVR3310`, `AVCA1HDA extends AVR5308`, …).
+predicates (`hasZones()`, `hasQuick()`, `getSupportedLevels()`, `supportsDAB()`, …). The other seven
+files in that directory are infrastructure: `AbstractModel`, `AbstractMarantzAV`, `IAVRModel`,
+`ModelArea`, `ModelConfigurator` and the two `DynamicEQ*` enums. All 60 reach `AbstractModel`, some
+directly and some through `AbstractMarantzAV` or another model class (`AVR990 extends AVR3310`, …).
 
 `ModelConfigurator.update()` resolves the model **by reflection** from the user's preference string:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ housekeeping items, each with file and line. Read it before proposing work of yo
 like an oversight is usually already listed there with the reason it was left alone. When you finish
 one of the items, tick its checkbox in the same commit.
 
+**[CONNECTION.md](CONNECTION.md) is the reference for everything network-facing** — the two
+transports, the reconnect loop and its generation counter, who decides when to hang up, and what
+Doze does to all of it. Read it before touching `core/ResilentConnector`, `core/Connector`,
+`ActiveHandler` or `http/HTTPSupport`; the non-obvious parts there are answers to field bugs.
+
 **[RELEASE.md](RELEASE.md) is the release procedure** — where the version lives, how signing is
 wired up, the tag convention, and the Play Console checklist with its deadlines. The one thing worth
 knowing before reading it: the `v*` tag workflow publishes to **GitHub Releases only**; there is no
@@ -99,7 +104,8 @@ The thread name is captured in `SDLogger.withThread()` at log time rather than i
 it stays right no matter which thread does the writing. Seen so far: `main`, `receiver`, `sender`,
 `StateCheckThread`, `LoadXMLStatus`, `StopConnector-Timer` and `ResilentThreadHandler-<n>`, where
 `<n>` is the `generation` counter from `ResilentConnector` and several can be alive at once. logcat
-has no such field because it carries its own tid column.
+has no such field because it carries its own tid column. What those names mean for a connection
+problem, and what a healthy and a broken sequence look like: [CONNECTION.md](CONNECTION.md).
 
 An exception is followed by its type, message and up to `MAX_TRACE` frames of stack, indented with
 tabs, `Caused by:` per cause. Before 1.6.1 the formatter dropped the `Throwable` entirely, so older
@@ -144,28 +150,12 @@ and an empty `BUILD_INFO` just means no line — the build must never fail over 
 
 ### Two independent transports
 
-1. **Telnet, port 23** — the real control channel. `core/Connector` holds a raw socket, writes
-   commands terminated with `\r`, and parses incoming lines into `InData`.
-2. **HTTP** — `http/AVRHTTPClient` scrapes the receiver's own web UI (`*.asp`, XML endpoints) for
-   things the telnet protocol does not expose: input/zone names, quick-select presets, NET audio
-   search. `http/Series08*` parse the 2008-series variant. Every request goes through
-   `http/HTTPSupport` (`HttpURLConnection`, GET and form POST, nothing else); its three callers are
-   `http/AVRHTTPClient`, `http/Series08Reader` and — easy to miss — `core/display/NetDisplay`.
-   Three things there are deliberate and load-bearing against the receivers' 2008-era GoAhead
-   webservers, and all three look removable to someone who does not know why they exist:
+Telnet on port 23 is the real control channel (`core/Connector`); HTTP on port 80 scrapes the
+receiver's own web UI for what telnet does not expose — input and zone names, quick-select presets,
+NET audio search (`http/AVRHTTPClient`, `http/Series08*`, all through `http/HTTPSupport`).
 
-   - `Accept-Encoding: identity` — the old Apache client never asked for gzip, Android does.
-   - `setFixedLengthStreamingMode` — so the request body is never sent chunked.
-   - `CookieHandler.setDefault(new CookieManager())` in `AVRApplication.onCreate`. The receivers
-     tested so far send no `Set-Cookie` at all, so this looks pointless — but `Series08Reader`
-     fetches `r_option1.asp` purely to establish state that the following `d_option1.asp` reads
-     back, and the Apache client it replaced carried a cookie store. Without a handler
-     `HttpURLConnection` shares nothing between requests, and the failure would be silent (empty
-     quick-select names). `readSeries08Info()` clears the store per run, because the old store was
-     per-client and did not outlive one read.
-
-   Receivers speak plain HTTP, so `android:usesCleartextTraffic="true"` in the manifest is
-   load-bearing too — removing it kills the whole scraping path.
+**[CONNECTION.md](CONNECTION.md) is the reference for both**, and worth reading before touching
+either: several things in `HTTPSupport` and in the reconnect loop look removable and are not.
 
 ### State flow
 
@@ -176,7 +166,8 @@ ResilentConnector (daemon thread, reconnect loop)  ->  Connector (socket)
 ```
 
 `ResilentConnector` runs a long-lived reconnect loop on a plain daemon thread owned by
-`AVRApplication` — **not** a Service. Killing or backgrounding the app kills the connection.
+`AVRApplication` — **not** a Service. Killing or backgrounding the app kills the connection. How
+that loop behaves, who tears it down and what Doze does to it: [CONNECTION.md](CONNECTION.md).
 
 `AVRApplication` is the central object graph: `getAvrState()`, `getConnector()`, `getEnableManager()`,
 `getModelConfigurator()`, `getDisplayManager()`, `getRenameService()`, `getMacroManager()` and more.
@@ -184,7 +175,8 @@ Activities reach everything through `(AVRApplication) getApplication()`.
 
 `EnableManager` drives view enablement from a small set of `StatusFlag`s (`Logging`, `WLAN`,
 `Reachable`, `Connected`, `Power`, `Zone1`–`Zone4`). This is why most buttons are greyed out until a
-receiver is actually connected — worth knowing when testing without hardware.
+receiver is actually connected — worth knowing when testing without hardware. The flags cascade into
+each other, see [CONNECTION.md](CONNECTION.md).
 
 `IStateFilter` decides which screen currently receives state updates, so background activities do not
 fight over the display listener.
@@ -289,8 +281,6 @@ Do not treat these as regressions; they predate the SDK 36 upgrade. Fixes are tr
 
 ## Next SDK step
 
-Local Network Protection becomes mandatory for apps targeting **Android 17 (SDK 37)**. That directly
-hits `scan/AVRScanner` (subnet sweep) and the raw receiver sockets — i.e. the core of the app. At
-`targetSdk 36` it does not apply yet, but plan for a runtime local-network permission before raising
-the target further. See [TODO.md](TODO.md) → *Next platform deadline: targetSdk 37* for the deprecated
-`WifiManager` calls to replace in the same pass.
+Local Network Protection becomes mandatory at **Android 17 (SDK 37)** and hits the core of the app —
+the subnet sweep and the receiver sockets. See [CONNECTION.md](CONNECTION.md) → *Next platform
+deadline* and [TODO.md](TODO.md) for the deprecated `WifiManager` calls to replace in the same pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,53 +75,16 @@ emulator instead. Four limits are worth knowing before writing more tests:
   load-bearing half of the argument, it lives in `Reconnector.run()`'s `isCurrent()` checks and
   `publishConnector()`, and no JVM test reaches it — read those before touching either.
 
-**Reading a log a user sent in** (`log/SDLogger` writes it, `log/FeedbackReporter` mails it). One
-line looks like this, and a message can run over several lines — anything not matching the header is
-a continuation:
-
-```
-2026-08-04  20:22:07.667 #0 - INFO : [main] openend at Tue Aug 04 20:22:07 GMT+02:00 2026
-```
-
-**Sort by `#seq`, never by timestamp or line order.** Neither of those is the order the events
-happened in: `java.util.logging` stamps the time when the `LogRecord` is built but writes later, so
-threads overtake each other — the field log from 2026-08-03 has 7 inversions in its 2488 header
-lines, one of them right where it mattered. (Count header lines only. A naive line-wise check counts
-the 184 continuation lines too and reports 99, which is wrong.) Sorting by the timestamp does not
-repair it either, because it only has millisecond resolution and 65 % of those lines share a
-millisecond with another. `#seq` comes from `LogRecord`, assigned in the constructor from the same
-instant as the time, and it is the one total order **within one process run** — on two runs from a
-Pixel 8 it removed every inversion (9 and 4 respectively, 0 after sorting).
-
-`#seq` restarts at `#0` in each process, and one log file usually holds several runs appended, so
-**split on the `openend at` lines before sorting**. Sorting a whole file by `#seq` interleaves the
-runs and produces garbage: on that same file it turned 13 inversions into 259. The counter can also
-have gaps — it is JVM-global and a rotation boundary cuts the file mid-stream — though in practice
-nothing else in the process uses `java.util.logging`, and one of those runs was gapless from `#0` to
-`#689`.
-
-The thread name is captured in `SDLogger.withThread()` at log time rather than in the formatter, so
-it stays right no matter which thread does the writing. Seen so far: `main`, `receiver`, `sender`,
-`StateCheckThread`, `LoadXMLStatus`, `StopConnector-Timer` and `ResilentThreadHandler-<n>`, where
-`<n>` is the `generation` counter from `ResilentConnector` and several can be alive at once. logcat
-has no such field because it carries its own tid column. What those names mean for a connection
-problem, and what a healthy and a broken sequence look like: [CONNECTION.md](CONNECTION.md).
-
-An exception is followed by its type, message and up to `MAX_TRACE` frames of stack, indented with
-tabs, `Caused by:` per cause. Before 1.6.1 the formatter dropped the `Throwable` entirely, so older
-logs carry only the message — `reading macros.txt failed` there could be the harmless
-`FileNotFoundException` it usually is, or anything else.
-
-`ReceiverStatus.toString()` walks `StatusFlag.values()` rather than its own map, so the flags always
-appear in the same order and two status lines can be diffed as text. Over the map they could not:
-3 of the 11 flag sets in that field log show up in more than one order, two of them in three.
+**A log a user sent in** (`log/SDLogger` writes it, `log/FeedbackReporter` mails it) has one
+header line per entry and carries a `#seq` and a thread name. Sort by `#seq`, never by timestamp
+or line order, and split runs on `openend at` first — the reasoning, and how to read a connection
+problem out of one, is in [CONNECTION.md](CONNECTION.md) → *Reading a log*.
 
 Lint runs with `abortOnError = false`, so lint *errors* do not fail the build — check
 `app/build/reports/lint-results-debug.html` explicitly when it matters.
 
-Release builds are signed only when `~/keystore.properties` exists or the `KEY_ALIAS` /
-`KEY_PASSWORD` / `STORE_FILE` / `STORE_PASSWORD` env vars are set; otherwise
-`app-release-unsigned.apk` is produced and cannot be installed — see [RELEASE.md](RELEASE.md).
+Release builds are only signed when a keystore is configured; otherwise the build silently produces
+an unusable `app-release-unsigned.apk`. Conditions and setup: [RELEASE.md](RELEASE.md).
 
 Debug builds show a greyed-out line with branch, short commit hash and commit time above the status
 bar (`R.id.textBuildInfo` in `tabhost.xml`, switched visible in `AVRRemote.onCreate`). The value comes
@@ -165,18 +128,16 @@ ResilentConnector (daemon thread, reconnect loop)  ->  Connector (socket)
         -> IGUIExecutor (Handler.post) ->  main thread
 ```
 
-`ResilentConnector` runs a long-lived reconnect loop on a plain daemon thread owned by
-`AVRApplication` — **not** a Service. Killing or backgrounding the app kills the connection. How
-that loop behaves, who tears it down and what Doze does to it: [CONNECTION.md](CONNECTION.md).
+The reconnect loop behind that first arrow, who tears it down and what Doze does to it:
+[CONNECTION.md](CONNECTION.md).
 
 `AVRApplication` is the central object graph: `getAvrState()`, `getConnector()`, `getEnableManager()`,
 `getModelConfigurator()`, `getDisplayManager()`, `getRenameService()`, `getMacroManager()` and more.
 Activities reach everything through `(AVRApplication) getApplication()`.
 
-`EnableManager` drives view enablement from a small set of `StatusFlag`s (`Logging`, `WLAN`,
-`Reachable`, `Connected`, `Power`, `Zone1`–`Zone4`). This is why most buttons are greyed out until a
-receiver is actually connected — worth knowing when testing without hardware. The flags cascade into
-each other, see [CONNECTION.md](CONNECTION.md).
+`EnableManager` drives view enablement from a small set of `StatusFlag`s, which is why most buttons
+are greyed out until a receiver is actually connected — worth knowing when testing without hardware.
+The flags and their cascade: [CONNECTION.md](CONNECTION.md).
 
 `IStateFilter` decides which screen currently receives state updates, so background activities do not
 fight over the display listener.
@@ -243,9 +204,8 @@ Consequences:
 - **Within Java 11, write modern Java.** The code dates from 2010 and mostly predates it, but new and
   touched code should not imitate that. In particular use **try-with-resources** rather than the
   manual `try { … } finally { x.close(); }` pattern — `http/HTTPSupport` is the reference. The old
-  pattern is still in 12 places (`core/Connector`, `core/MacroManager`, `log/FeedbackReporter`,
-  the three `http/Series08*Parser`, `core/RenameService`, `scan/AVRTargetTester`);
-  converting one is welcome when you are editing that code anyway, but do not sweep the tree as a
+  pattern survives in a dozen places (inventory in [TODO.md](TODO.md)); converting one is welcome
+  when you are editing that code anyway, but do not sweep the tree as a
   side errand — and note `core/Connector.java:168` is not convertible at all, it closes the socket
   only on the failure path (`if (!ok)`). The other reason to keep the manual form is when
   an exception from `close()` must be swallowed deliberately — see
@@ -271,16 +231,8 @@ Three things are easy to forget and all are required at `targetSdk 36`:
 3. If the activity requests a runtime permission, gate the request on
    `savedInstanceState == null` — these activities are recreated on every rotation.
 
-## Known-broken, pre-existing
+## Known-broken, and what comes next
 
-Do not treat these as regressions; they predate the SDK 36 upgrade. Fixes are tracked in
-[TODO.md](TODO.md) → *Broken today*:
-
-- The custom-background picker (`AVRSettings`) stores the URI without
-  `takePersistableUriPermission()`, so it does not survive a restart.
-
-## Next SDK step
-
-Local Network Protection becomes mandatory at **Android 17 (SDK 37)** and hits the core of the app —
-the subnet sweep and the receiver sockets. See [CONNECTION.md](CONNECTION.md) → *Next platform
-deadline* and [TODO.md](TODO.md) for the deprecated `WifiManager` calls to replace in the same pass.
+Both live in [TODO.md](TODO.md): behaviour that is already broken and predates the SDK 36 upgrade
+(do not report it as a regression), and the next platform deadline, Local Network Protection at
+Android 17. The connection side of that deadline is in [CONNECTION.md](CONNECTION.md).

--- a/CONNECTION.md
+++ b/CONNECTION.md
@@ -4,11 +4,17 @@ How the app talks to a receiver: the two transports, the reconnect loop that kee
 socket alive, who decides when to hang up, and what Android's background restrictions do to all of
 it.
 
-Read this before touching `core/ResilentConnector`, `core/Connector` or `ActiveHandler`. Most of
-what looks removable in there is load-bearing, and the reasons are field observations rather than
-theory. Open work is in [TODO.md](TODO.md); this file describes what the code does today.
+Read this before touching `core/ResilentConnector`, `core/Connector`, `ActiveHandler` or
+`http/HTTPSupport`. Most of what looks removable in there is load-bearing, and the reasons are field
+observations rather than theory. Open work is in [TODO.md](TODO.md); this file describes what the
+code does today.
 
 ## Two independent transports
+
+Ports 23 and 80 are the defaults; `ConnectionConfiguration` also parses
+`IP[:controlport[:httpport[:httpip]]]`. That matters beyond the port number — with such an extended
+config `checkAddress()` returns `true` without probing anything, so the reachability story below
+does not apply to those users at all.
 
 1. **Telnet, port 23** — the real control channel. `core/Connector` holds a raw socket, writes
    commands terminated with `\r`, and parses incoming lines into `InData`. Two daemon threads per
@@ -45,9 +51,10 @@ decision and still open in [TODO.md](TODO.md).
 
 One pass of `Reconnector.run()`: probe reachability (`checkAddress()`), open a `Connector`, publish
 it, then block in `waitUntilClosed()` until the socket drops; probe again, clear the state, wait,
-repeat. The wait is `RECONNECT_DELAY` = 1, 2, 4, 8, 16 seconds, and **the index only resets after a
-successful connection** — sitting in the foreground through a bad patch can leave you waiting 16 s
-after the network is fine again. A resume escapes it, because `forceReconnect()` builds a fresh
+repeat. The wait comes from `RECONNECT_DELAY` and runs **2, 4, 8, 16 s** — the array's leading `1`
+is never used, because the index is incremented before the sleep. **It only resets after a
+successful connection**, so sitting in the foreground through a bad patch can leave you waiting 16 s
+after the network is fine again. A resume escapes it: `forceReconnect()` builds a fresh
 `Reconnector` whose index starts at 0.
 
 ### Why nothing waits for the old thread
@@ -59,15 +66,16 @@ because the thread is typically inside `ConnectionConfiguration.checkAddress()` 
 a second of blocked UI thread, since `stopConnector()` is reached from `ActiveHandler` on the main
 thread. `core/ThreadHandlerTest` pins that it returns promptly.
 
-So a superseded thread keeps running for up to a few seconds. Everything that keeps it harmless
-rests on one mechanism:
+So a superseded thread keeps running for a few seconds, and **several of them can be alive at
+once**. Their log lines are distinguishable: the thread is named `ResilentThreadHandler-<n>`, where
+`<n>` is the generation. Everything that keeps them harmless rests on one mechanism:
 
 ### The generation counter
 
-`ResilentConnector.generation` is an `AtomicInteger`; every `Reconnector` captures its value as
-`epoch` at construction. `stopConnector()` bumps the counter **before** tearing anything down, so a
-superseded thread sees `isCurrent() == false` and must not touch shared state any more. Every write
-in `run()` is guarded by it.
+`ResilentConnector.generation` is an `AtomicInteger`. `startConnector()` bumps it and hands the new
+value to the `Reconnector` as its `epoch`; `stopConnector()` bumps it **before** tearing anything
+down, so a superseded thread sees `isCurrent() == false` and must not touch shared state any more.
+Every write in `run()` is guarded by it.
 
 Two of those guards need more than a check:
 
@@ -76,13 +84,11 @@ Two of those guards need more than a check:
   the window: if the bump lands between check and assignment, a superseded thread drops a **live**
   `Connector` into the field after the cleanup already ran. Nobody closes that socket, the receiver
   keeps a second telnet session open, and `isRunning()` reports the dead connection as current —
-  which is exactly how the reconnect loop once went missing entirely.
+  the same shape as the failure in *What Doze does* below, reached by a different route. That one
+  was observed; this one was reasoned about in PR #26 and guarded before it could happen.
 - The block after the second `checkAddress()` is guarded because that call blocks about a second in
-  ping and port timeouts, which is the widest window in the loop. The guard narrows it; what
-  actually closes it is `publishConnector()` underneath.
-
-Because nothing waits, **several reconnect threads can be alive at once**. Their log lines are
-distinguishable: the thread is named `ResilentThreadHandler-<n>`, where `<n>` is the generation.
+  ping and port timeouts. The guard narrows the window; what actually closes it is
+  `publishConnector()` underneath.
 
 ## Who decides when to hang up
 
@@ -92,13 +98,17 @@ distinguishable: the thread is named `ResilentThreadHandler-<n>`, where `<n>` is
 - **`contextPaused()`** schedules a `StopConnectorTask` on the `StopConnector-Timer` after the
   user's *disconnect time* (`AVRSettings.getDisconnectTimeout`, default 10 s, selectable up to
   7200 s). Nothing is torn down immediately — the screen going off just pauses the activity.
-- **`contextResumed()`** picks one of two paths. Back within a minute *and* `isRunning()` → leave
-  the connection alone. Otherwise → `forceReconnect()`, unconditionally.
+- **`contextResumed()`** picks one of three paths, on a *quick return* — back within the **shorter**
+  of the disconnect time and `MAX_QUICK_RETURN_SEC` (60 s), so 10 s at the default:
+  - quick return and `isRunning()` → leave the connection alone,
+  - quick return but not running → `reconfigure()`, which itself short-circuits if the config is
+    unchanged and a loop is already running,
+  - otherwise → `forceReconnect()`, unconditionally.
 
-The minute is `MAX_QUICK_RETURN_SEC` and is deliberately not the user's disconnect time. The
-shortcut trusts `isRunning()`, which rests on `Socket.isConnected()` — and that stays `true`
-forever once a connect succeeded, including for a socket Doze severed hours ago. The shortcut is
-for rotation, dialogs and tab switches; anything longer gets a fresh connection.
+The 60 s are a cap, not the window, and the reason for the cap is that the disconnect time may be
+set as high as two hours while `isRunning()` is only worth seconds: it rests on
+`Socket.isConnected()`, which stays `true` forever once a connect succeeded, including for a socket
+Doze severed long ago. The shortcut is for rotation, dialogs and tab switches.
 
 `StopConnectorTask` also checks whether an activity became active again before it fires, and
 reconnects itself if a resume slipped in between its check and the stop. Both belong to the Doze
@@ -130,11 +140,15 @@ against an AVR-3310 on 2.4 GHz, all three within a minute of each other:
 | phone, awake for a while | 46–62 ms | connects |
 | phone, just woken | fails entirely | 2500 ms connect timeout |
 
-The radio sleeps between beacons and only wakes on DTIM. `AVRTargetTester.PING_TIMEOUT` is 250 ms,
-so right after the user picks the phone up, `checkAddress()` reports "not reachable" for a receiver
-that is plainly there. The connect is attempted regardless — the *"Auf jeden Fall versuchen"*
-comment in `Reconnector.run()` covers that — so this is about displayed state and the backoff, not
-about refusing to connect. Still open, see [TODO.md](TODO.md).
+The Mac is the control here: it kept answering throughout, so the receiver was demonstrably up the
+whole time.
+
+The radio sleeps between beacons and only wakes on DTIM. `AVRTargetTester.PING_TIMEOUT` is 250 ms
+for the pre-connect probe and twice that for the one after a close (`cfgTest` doubles it), so right
+after the user picks the phone up, `checkAddress()` reports "not reachable" for a receiver that is
+plainly there. The connect is attempted regardless — the *"Auf jeden Fall versuchen"* comment in
+`Reconnector.run()` covers that — so this is about displayed state and the backoff, not about
+refusing to connect. Still open, see [TODO.md](TODO.md).
 
 **The process can also simply be reclaimed**, and then the daemon thread dies with it. That is the
 Service item in [TODO.md](TODO.md). Worth stressing: the field report above was *not* this. The
@@ -147,21 +161,62 @@ process had survived — `openend at` appears only at the app's own restart.
 greyed out until a receiver is actually connected — worth knowing when testing without hardware.
 
 The flags are not independent. `setStatus()` cascades through a deliberate `switch` fallthrough:
-clearing `Reachable` also clears `Connected`, `Power` and every zone. **One missed ping response
-greys out the entire UI** — which is what makes the `PING_TIMEOUT` observation above more than
+clearing `Reachable` also clears `Connected`, `Power` and zones 1–3. **One missed ping response
+greys out nearly the whole UI** — which is what makes the `PING_TIMEOUT` observation above more than
 cosmetic. Setting cascades the other way: `Power` implies `Connected` implies `Reachable`.
 
-## Reading a connection problem out of a log
+`Zone4` is missing from that reset — see [TODO.md](TODO.md). It is a real flag with a real zone
+behind it, so on a four-zone receiver those controls stay enabled after the connection drops.
 
-See [CLAUDE.md](CLAUDE.md) for the log format itself (sort by `#seq`, split runs on `openend at`).
-For connection questions the thread name carries most of the signal:
+## Reading a log
+
+`log/SDLogger` writes it, `log/FeedbackReporter` mails it. One line looks like this, and a message
+can run over several lines — anything not matching the header is a continuation:
+
+```
+2026-08-04  20:22:07.667 #0 - INFO : [main] openend at Tue Aug 04 20:22:07 GMT+02:00 2026
+```
+
+**Sort by `#seq`, never by timestamp or line order.** Neither of those is the order the events
+happened in: `java.util.logging` stamps the time when the `LogRecord` is built but writes later, so
+threads overtake each other — the field log from 2026-08-03 has 7 inversions in its 2488 header
+lines, one of them right where it mattered. (Count header lines only. A naive line-wise check counts
+the 184 continuation lines too and reports 99, which is wrong.) Sorting by the timestamp does not
+repair it either, because it only has millisecond resolution and 65 % of those lines share a
+millisecond with another. `#seq` comes from `LogRecord`, assigned in the constructor from the same
+instant as the time, and it is the one total order **within one process run** — on two runs from a
+Pixel 8 it removed every inversion (9 and 4 respectively, 0 after sorting).
+
+`#seq` restarts at `#0` in each process, and one log file usually holds several runs appended, so
+**split on the `openend at` lines before sorting**. Sorting a whole file by `#seq` interleaves the
+runs and produces garbage: on that same file it turned 13 inversions into 259. The counter can also
+have gaps — it is JVM-global and a rotation boundary cuts the file mid-stream — though in practice
+nothing else in the process uses `java.util.logging`, and one of those runs was gapless from `#0` to
+`#689`.
+
+An exception is followed by its type, message and up to `MAX_TRACE` frames of stack, indented with
+tabs, `Caused by:` per cause. Before 1.6.1 the formatter dropped the `Throwable` entirely, so older
+logs carry only the message — `reading macros.txt failed` there could be the harmless
+`FileNotFoundException` it usually is, or anything else.
+
+`ReceiverStatus.toString()` walks `StatusFlag.values()` rather than its own map, so the flags always
+appear in the same order and two status lines can be diffed as text. Over the map they could not:
+3 of the 11 flag sets in that field log show up in more than one order, two of them in three.
+
+### What the thread names tell you
+
+The name is captured in `SDLogger.withThread()` at log time rather than in the formatter, so it
+stays right no matter which thread does the writing. logcat has no such field — it carries its own
+tid column. For connection questions this is where most of the signal is:
 
 | thread | what it is |
 | --- | --- |
 | `main` | lifecycle, `forceReconnect`, everything from an activity |
-| `ResilentThreadHandler-<n>` | a reconnect loop, `<n>` is its generation |
+| `ResilentThreadHandler-<n>` | a reconnect loop, `<n>` is its generation; several can be alive |
 | `receiver` / `sender` | the two socket threads of one `Connector` |
 | `StopConnector-Timer` | the auto-disconnect timer |
+| `StateCheckThread` | the re-query after a connection came up (`core/AVRState`) |
+| `LoadXMLStatus` | the HTTP scraping from `StatusAreaManager` |
 
 A healthy start looks like this — one generation, and data arriving:
 
@@ -173,11 +228,14 @@ A healthy start looks like this — one generation, and data arriving:
 #156 [receiver]                  RECEIVED [PWSTANDBY(...)]
 ```
 
-A handover, which is normal on resume — the old generation is detached, a new one takes over:
+A normal teardown and re-establish — the auto-disconnect timer drops the connection while the app is
+in the background, the user comes back 13 s later, a new generation takes over. Note that the two
+sides run on different threads, which is how you tell them apart:
 
 ```
 #439 [StopConnector-Timer]       Reconnector:connector detached (ResilentThreadHandler-2)
 #440 [ResilentThreadHandler-2]   Reconnector:connector interrupted -> return
+#465 [main]                      Reconnector:start new connector 192.168.10.30
 #467 [ResilentThreadHandler-5]   Reconnector:build new connection to [192.168.10.30]
 ```
 

--- a/CONNECTION.md
+++ b/CONNECTION.md
@@ -1,0 +1,204 @@
+# CONNECTION.md
+
+How the app talks to a receiver: the two transports, the reconnect loop that keeps the telnet
+socket alive, who decides when to hang up, and what Android's background restrictions do to all of
+it.
+
+Read this before touching `core/ResilentConnector`, `core/Connector` or `ActiveHandler`. Most of
+what looks removable in there is load-bearing, and the reasons are field observations rather than
+theory. Open work is in [TODO.md](TODO.md); this file describes what the code does today.
+
+## Two independent transports
+
+1. **Telnet, port 23** — the real control channel. `core/Connector` holds a raw socket, writes
+   commands terminated with `\r`, and parses incoming lines into `InData`. Two daemon threads per
+   connection, `receiver` and `sender`; the sender paces commands by `SEND_DELAY` (100 ms) because
+   the receivers drop them otherwise.
+2. **HTTP, port 80** — `http/AVRHTTPClient` scrapes the receiver's own web UI (`*.asp`, XML
+   endpoints) for things the telnet protocol does not expose: input/zone names, quick-select
+   presets, NET audio search. `http/Series08*` parse the 2008-series variant. Every request goes
+   through `http/HTTPSupport` (`HttpURLConnection`, GET and form POST, nothing else); its three
+   callers are `http/AVRHTTPClient`, `http/Series08Reader` and — easy to miss —
+   `core/display/NetDisplay`.
+
+Three things in `HTTPSupport` are deliberate and load-bearing against the receivers' 2008-era
+GoAhead webservers, and all three look removable to someone who does not know why they exist:
+
+- `Accept-Encoding: identity` — the old Apache client never asked for gzip, Android does.
+- `setFixedLengthStreamingMode` — so the request body is never sent chunked.
+- `CookieHandler.setDefault(new CookieManager())` in `AVRApplication.onCreate`. The receivers
+  tested so far send no `Set-Cookie` at all, so this looks pointless — but `Series08Reader` fetches
+  `r_option1.asp` purely to establish state that the following `d_option1.asp` reads back, and the
+  Apache client it replaced carried a cookie store. Without a handler `HttpURLConnection` shares
+  nothing between requests, and the failure would be silent (empty quick-select names).
+  `readSeries08Info()` clears the store per run, because the old store was per-client and did not
+  outlive one read.
+
+Receivers speak plain HTTP, so `android:usesCleartextTraffic="true"` in the manifest is
+load-bearing too — removing it kills the whole scraping path.
+
+## The reconnect loop
+
+`ResilentConnector` runs a long-lived loop on a plain daemon thread owned by `AVRApplication` —
+**not** a Service. Killing or backgrounding the app kills the connection. That is a 2010 design
+decision and still open in [TODO.md](TODO.md).
+
+One pass of `Reconnector.run()`: probe reachability (`checkAddress()`), open a `Connector`, publish
+it, then block in `waitUntilClosed()` until the socket drops; probe again, clear the state, wait,
+repeat. The wait is `RECONNECT_DELAY` = 1, 2, 4, 8, 16 seconds, and **the index only resets after a
+successful connection** — sitting in the foreground through a bad patch can leave you waiting 16 s
+after the network is fine again. A resume escapes it, because `forceReconnect()` builds a fresh
+`Reconnector` whose index starts at 0.
+
+### Why nothing waits for the old thread
+
+`stopConnector()` interrupts the reconnect thread and returns immediately. It does **not** join it,
+because the thread is typically inside `ConnectionConfiguration.checkAddress()` →
+`InetAddress.isReachable()` plus a few `testPort()` connects, and none of those react to
+`interrupt()`. Waiting ran into its full timeout and then continued with the thread still alive —
+a second of blocked UI thread, since `stopConnector()` is reached from `ActiveHandler` on the main
+thread. `core/ThreadHandlerTest` pins that it returns promptly.
+
+So a superseded thread keeps running for up to a few seconds. Everything that keeps it harmless
+rests on one mechanism:
+
+### The generation counter
+
+`ResilentConnector.generation` is an `AtomicInteger`; every `Reconnector` captures its value as
+`epoch` at construction. `stopConnector()` bumps the counter **before** tearing anything down, so a
+superseded thread sees `isCurrent() == false` and must not touch shared state any more. Every write
+in `run()` is guarded by it.
+
+Two of those guards need more than a check:
+
+- **`publishConnector(epoch, c)`** is `synchronized` and re-checks the epoch under the monitor,
+  against `closeAndClearConnector()`. A plain `if (isCurrent()) connector = c;` would only narrow
+  the window: if the bump lands between check and assignment, a superseded thread drops a **live**
+  `Connector` into the field after the cleanup already ran. Nobody closes that socket, the receiver
+  keeps a second telnet session open, and `isRunning()` reports the dead connection as current —
+  which is exactly how the reconnect loop once went missing entirely.
+- The block after the second `checkAddress()` is guarded because that call blocks about a second in
+  ping and port timeouts, which is the widest window in the loop. The guard narrows it; what
+  actually closes it is `publishConnector()` underneath.
+
+Because nothing waits, **several reconnect threads can be alive at once**. Their log lines are
+distinguishable: the thread is named `ResilentThreadHandler-<n>`, where `<n>` is the generation.
+
+## Who decides when to hang up
+
+`ActiveHandler` is the only owner of the disconnect policy. `AVRApplication.activityResumed()` and
+`activityPaused()` feed it; every activity reports through them.
+
+- **`contextPaused()`** schedules a `StopConnectorTask` on the `StopConnector-Timer` after the
+  user's *disconnect time* (`AVRSettings.getDisconnectTimeout`, default 10 s, selectable up to
+  7200 s). Nothing is torn down immediately — the screen going off just pauses the activity.
+- **`contextResumed()`** picks one of two paths. Back within a minute *and* `isRunning()` → leave
+  the connection alone. Otherwise → `forceReconnect()`, unconditionally.
+
+The minute is `MAX_QUICK_RETURN_SEC` and is deliberately not the user's disconnect time. The
+shortcut trusts `isRunning()`, which rests on `Socket.isConnected()` — and that stays `true`
+forever once a connect succeeded, including for a socket Doze severed hours ago. The shortcut is
+for rotation, dialogs and tab switches; anything longer gets a fresh connection.
+
+`StopConnectorTask` also checks whether an activity became active again before it fires, and
+reconnects itself if a resume slipped in between its check and the stop. Both belong to the Doze
+story below.
+
+## What Doze does
+
+This is where the interesting failures come from. All of the following is observed, not theory.
+
+**The process is frozen and broadcasts are delivered late.** This caused the one field report we
+have a log for (2026-08-03). `SCREEN_OFF` was queued at 18:27 while the app was in the background
+and arrived at 18:48:07.513 — 49 ms *after* the user brought the app back and `forceReconnect()` had
+started a new reconnect thread. The old `ACTION_SCREEN_OFF` receiver called `connector.stop()`
+unconditionally and invalidated exactly that thread. There is no way back from there: no further
+`contextResumed()` comes, because the activity is already resumed. The app looked dead until it was
+killed and restarted. The receiver is gone; `ActiveHandler` alone decides now.
+
+**Timers catch up.** `java.util.Timer` fires tasks it missed while the process was frozen, so a
+`StopConnectorTask` deferred by Doze can go off right after a resume and stop a connection that was
+just built. `cancelCurrentTask()` in `contextResumed()` only wins that race sometimes, hence the
+guard in the task, and the self-heal after it because check-then-act is not atomic.
+
+**Wi-Fi power save makes a reachable receiver look unreachable.** Measured 2026-08-04 on a Pixel 8
+against an AVR-3310 on 2.4 GHz, all three within a minute of each other:
+
+| | ping to the receiver | port 23 |
+| --- | --- | --- |
+| Mac on the same LAN | 8 ms | connects |
+| phone, awake for a while | 46–62 ms | connects |
+| phone, just woken | fails entirely | 2500 ms connect timeout |
+
+The radio sleeps between beacons and only wakes on DTIM. `AVRTargetTester.PING_TIMEOUT` is 250 ms,
+so right after the user picks the phone up, `checkAddress()` reports "not reachable" for a receiver
+that is plainly there. The connect is attempted regardless — the *"Auf jeden Fall versuchen"*
+comment in `Reconnector.run()` covers that — so this is about displayed state and the backoff, not
+about refusing to connect. Still open, see [TODO.md](TODO.md).
+
+**The process can also simply be reclaimed**, and then the daemon thread dies with it. That is the
+Service item in [TODO.md](TODO.md). Worth stressing: the field report above was *not* this. The
+process had survived — `openend at` appears only at the app's own restart.
+
+## How connection state reaches the UI
+
+`EnableManager` drives view enablement from a small set of `StatusFlag`s, in this order:
+`Logging`, `WLAN`, `Reachable`, `Connected`, `Power`, `Zone1`–`Zone4`. This is why most buttons are
+greyed out until a receiver is actually connected — worth knowing when testing without hardware.
+
+The flags are not independent. `setStatus()` cascades through a deliberate `switch` fallthrough:
+clearing `Reachable` also clears `Connected`, `Power` and every zone. **One missed ping response
+greys out the entire UI** — which is what makes the `PING_TIMEOUT` observation above more than
+cosmetic. Setting cascades the other way: `Power` implies `Connected` implies `Reachable`.
+
+## Reading a connection problem out of a log
+
+See [CLAUDE.md](CLAUDE.md) for the log format itself (sort by `#seq`, split runs on `openend at`).
+For connection questions the thread name carries most of the signal:
+
+| thread | what it is |
+| --- | --- |
+| `main` | lifecycle, `forceReconnect`, everything from an activity |
+| `ResilentThreadHandler-<n>` | a reconnect loop, `<n>` is its generation |
+| `receiver` / `sender` | the two socket threads of one `Connector` |
+| `StopConnector-Timer` | the auto-disconnect timer |
+
+A healthy start looks like this — one generation, and data arriving:
+
+```
+#79  [main]                      Reconnector:start new connector 192.168.10.30
+#81  [ResilentThreadHandler-2]   Reconnector:build new connection to [192.168.10.30]
+#83  [ResilentThreadHandler-2]   Reconnector:reachable 192.168.10.30 : true
+#145 [ResilentThreadHandler-2]   Reconnector:connection to [192.168.10.30] established
+#156 [receiver]                  RECEIVED [PWSTANDBY(...)]
+```
+
+A handover, which is normal on resume — the old generation is detached, a new one takes over:
+
+```
+#439 [StopConnector-Timer]       Reconnector:connector detached (ResilentThreadHandler-2)
+#440 [ResilentThreadHandler-2]   Reconnector:connector interrupted -> return
+#467 [ResilentThreadHandler-5]   Reconnector:build new connection to [192.168.10.30]
+```
+
+What a dead loop looked like before the fix — a teardown with no `start new connector` after it,
+and then nothing at all until the app was restarted:
+
+```
+activity resumed AVRRemote
+Connector forceReconnect ip: [192.168.10.30]
+Reconnector:start new connector 192.168.10.30
+System StandBy ...                            <- broadcast from 20 minutes earlier
+stop connector
+Reconnector:connector stopped
+```
+
+So: **a teardown line that is not followed by a new generation starting is the smell.**
+
+## Next platform deadline: targetSdk 37
+
+Local Network Protection becomes mandatory for apps targeting **Android 17 (SDK 37)**. That
+directly hits `scan/AVRScanner` (subnet sweep) and the raw receiver sockets — i.e. everything on
+this page. At `targetSdk 36` it does not apply yet, but plan for a runtime local-network permission
+before raising the target further. See [TODO.md](TODO.md) for the deprecated `WifiManager` calls to
+replace in the same pass.

--- a/TODO.md
+++ b/TODO.md
@@ -130,6 +130,16 @@ blocks the current build, which is green.
       as buttons that stay greyed out until the next status change repairs them. Cheaper to fix than
       it looks: `fireListener()` only copies the status and `Handler.post()`s it, so a `synchronized`
       on `setStatus()` would cover a few field writes and a post, never the UI fanout itself.
+- [ ] **`EnableManager.setStatus()` forgets `Zone4` when it clears.** The `Power` case of the
+      remove-fallthrough resets `Zone1`, `Zone2` and `Zone3` and stops there
+      (`EnableManager.java:131-136`), but `Zone4` is a real flag with a real zone behind it
+      (`core/Zone.java:25`). On a four-zone receiver its controls therefore stay enabled after the
+      connection drops, while zones 1–3 grey out — so it is visibly inconsistent, not just
+      theoretical. One line, but check first whether any four-zone model is actually reachable in
+      `@array/modelNames` before calling it user-visible.
+- [ ] `ResilentConnector.java:159` logs `Reconnector:Reconnector:connection to [...] closed` — the
+      prefix is doubled. Cosmetic, but anyone grepping a log against
+      [CONNECTION.md](CONNECTION.md) trips over it.
 - [ ] **`AVRTargetTester.PING_TIMEOUT` is 250 ms, which a phone waking from standby cannot meet.**
       Wi-Fi power save puts the receiver out of reach for the first moments after the user picks the
       phone up, so `checkAddress()` reports "not reachable" for a device that is plainly there — the

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,8 @@ blocks the current build, which is green.
 
 - [ ] **Local Network Protection becomes mandatory** for apps targeting Android 17. It affects the
       core of this app: the subnet sweep in `scan/AVRScanner` and the raw sockets to the receiver.
-      Needs the new local-network runtime permission and a rationale UI.
+      Needs the new local-network runtime permission and a rationale UI. Background:
+      [CONNECTION.md](CONNECTION.md).
 - [ ] Same area, do it in one pass: `scan/WiFiInfo` relies on `WifiManager.getDhcpInfo()` (netmask
       and local IP for the sweep) and `ConnectivityManager.getNetworkInfo(TYPE_WIFI)`, plus
       `AVRApplication.java:63`. Both deprecated — `getDhcpInfo()` since API 31, the
@@ -92,7 +93,7 @@ blocks the current build, which is green.
       A design decision from 2010. Under modern background restrictions the process can be reclaimed
       and the connection dies with it. Note that the one "app does not reconnect after standby"
       report we have a log for was *not* this — the process had survived; it was the stale-teardown
-      race in the item below.
+      race in the item below. How the loop works today: [CONNECTION.md](CONNECTION.md).
 - [x] `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()`
       runs on the UI thread and waited there for the old reconnect thread — a full second whenever
       that thread sat in `checkAddress()`, because neither `InetAddress.isReachable()` nor the
@@ -130,23 +131,12 @@ blocks the current build, which is green.
       it looks: `fireListener()` only copies the status and `Handler.post()`s it, so a `synchronized`
       on `setStatus()` would cover a few field writes and a post, never the UI fanout itself.
 - [ ] **`AVRTargetTester.PING_TIMEOUT` is 250 ms, which a phone waking from standby cannot meet.**
-      Measured on a Pixel 8 against an AVR-3310 on 2.4 GHz, all three within seconds of each other:
-      a Mac on the same LAN pings the receiver in 8 ms, the phone once properly awake needs **62 ms**,
-      and in the first moments after waking it does not get through at all — ICMP fails and even the
-      2500 ms TCP connect to port 23 times out, while the receiver answers the Mac the whole time.
-      That is Wi-Fi power save: the radio sleeps between beacons and only wakes on DTIM. So
-      `checkAddress()` reports "not reachable" for a receiver that is plainly there, exactly in the
-      situation where a user has just picked the phone up.
-      Consequences, in the order they bite: `setStatus(Reachable, false)` cascades in `EnableManager`
-      and greys out the whole UI; the reconnect delay climbs 1→2→4→8→16 s and only resets on a
-      *successful* connection, so staying in the foreground through a bad patch can leave the user
-      waiting 16 s after the network is fine again (a resume escapes it, `forceReconnect()` builds a
-      fresh `Reconnector` with the index at 0). The connect itself is attempted regardless — the
-      "Auf jeden Fall versuchen" comment in `Reconnector.run()` covers that — so this is about the
-      displayed state and the backoff, not about refusing to connect.
+      Wi-Fi power save puts the receiver out of reach for the first moments after the user picks the
+      phone up, so `checkAddress()` reports "not reachable" for a device that is plainly there — the
+      measurement and what it costs the user is in [CONNECTION.md](CONNECTION.md) → *What Doze does*.
       This may well be part of what users report as "does not reconnect after standby". Worth
-      measuring before changing: raising the timeout costs a slower subnet sweep in `scan/AVRScanner`,
-      which uses the same constant, so the two uses probably want separate values.
+      measuring before changing: `scan/AVRScanner` uses the same constant for its subnet sweep, and
+      raising it there costs scan time, so the two uses probably want separate values.
 
 ## Time bomb, no fuse length known
 


### PR DESCRIPTION
Reine Dokumentation, kein Code.

## Warum

Drei PRs an einem Tag (#25, #26, #28) haben am Verbindungscode gearbeitet, und das Wissen daraus lag verstreut: in Commit-Messages, in Code-Kommentaren, in `TODO.md`-Einträgen. `CLAUDE.md` beschrieb die Transporte und den Zustandsfluss, sagte aber nichts über das, was die Fehler verursacht hat — was Android im Doze mit dem Prozess macht, wann die Verbindung absichtlich fällt und wann versehentlich. Wer den nächsten „App verbindet nach dem Standby nicht"-Report bearbeitet, musste das aus `git log` rekonstruieren.

## Die neue Datei

`CONNECTION.md` in der Repo-Wurzel, Konvention wie `RELEASE.md`/`TODO.md`. 204 Zeilen, aufgebaut entlang der Frage „wie kommt die Verbindung zustande, was hält sie, was killt sie":

1. **Zwei Transporte** — Telnet 23 und HTTP 80, samt der drei load-bearing `HTTPSupport`-Details und `usesCleartextTraffic`
2. **Der Reconnect-Loop** — Backoff 1→2→4→8→16 s und dass er nur nach erfolgreicher Verbindung zurücksetzt; warum `stopConnector()` nicht auf den alten Thread wartet; der `generation`-Zähler und warum `publishConnector()` atomar sein muss und ein `if (isCurrent())` davor nicht reicht
3. **Wer auflegt** — `ActiveHandler` als alleiniger Besitzer, der 60-Sekunden-Deckel und warum `Socket.isConnected()` nicht zu trauen ist
4. **Was Doze tut** — nachgereichte Broadcasts (der #25-Bug mit Zeitstempeln aus dem Feld-Log), nachholende Timer, WLAN-Powersave mit Messtabelle
5. **Wie der Zustand in der UI landet** — die Flag-Kaskade: ein verpasster Ping graut alles aus
6. **Ein Verbindungsproblem im Log lesen** — Thread-Tabelle, eine gesunde Sequenz, eine Ablösung, und wie der tote Loop aussah. Merksatz: eine Teardown-Zeile ohne folgende neue Generation ist das Symptom.
7. **targetSdk 37** — Local Network Protection

## Was aus CLAUDE.md herausgeht

`### Two independent transports` und `## Next SDK step` schrumpfen auf je zwei, drei Sätze mit Verweis; aus `### State flow` gehen der `ResilentConnector`-Absatz und die Flag-Erklärung mit Verweis heraus. **Bleiben** — das ist Architektur, nicht Verbindung — das ASCII-Diagramm, der `AVRApplication`-Objektgraph, `IStateFilter`, die Display-Parser und die Zonen/Empfänger-Zählung. Der Abschnitt zum Log-Format bleibt auch, verweist aber bei den Thread-Namen weiter.

Faustregel: `CLAUDE.md` sagt *dass* es einen Reconnect-Loop gibt und wo er hängt, `CONNECTION.md` sagt *wie* er sich verhält und *warum* er so gebaut ist.

## Geprüft

- **Kein Inhaltsverlust**: alle zehn Substanzbegriffe aus den gelöschten Absätzen sind in der neuen Datei wiederzufinden — besonders die drei HTTP-Details, die ausdrücklich gegen „sieht entfernbar aus" geschrieben wurden.
- **Jede Zahl am Code nachgeschlagen** statt aus dem Gedächtnis: `SEND_DELAY` 100, `RECONNECT_DELAY {1,2,4,8,16}`, `MAX_QUICK_RETURN_SEC` 60, Default-Trennzeit 10 s, `AVR_CONNECT_TIMEOUT` 2500, `PING_TIMEOUT` 250, die Thread-Namen, die `StatusFlag`-Reihenfolge. In diesem Projekt haben drei Review-Runden hintereinander sachlich falsche Begründungen in Kommentaren gefunden — das war der Anlass, hier nichts zu schätzen.
- **Alle Querverweise lösen auf**, auch der Abschnittsverweis aus `TODO.md` auf *What Doze does*.
- **Messungen mit Datum**: Feld-Log 2026-08-03, Pixel-Messung 2026-08-04.
- `./gradlew build` grün, `git status` zeigt nur Doku.

## Zwei Abweichungen vom Plan

**`README.md` unangetastet** — es gibt dort keine Doku-Übersicht zum Ergänzen, und die Datei richtet sich an Leute, die das Projekt finden, nicht an Leute, die daran arbeiten.

**Der `PING_TIMEOUT`-Eintrag in `TODO.md` ist gekürzt** statt unverändert geblieben: er hätte sonst eine zweite Kopie der Messtabelle getragen, und solche Duplikate driften auseinander. Jetzt steht dort, was ein Backlog-Eintrag braucht, mit Verweis auf die Beobachtung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9yDPoKDmCwL971LAYKbTr