### PR TITLE
Fix NPE crash on Wi-Fi broadcast: getNetworkInfo(TYPE_WIFI) returns null

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,9 +28,13 @@ blocks the current build, which is green.
       state the `WifiManager` broadcast reports, so the receiver crashed on the event it exists to
       handle. The lines were unchanged since the initial commit, so 1.6.0 was affected identically.
       Both call sites now go through `WiFiInfo.isWiFiConnected(ConnectivityManager)`, which asks
-      `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` about the **active** network — unbound
-      sockets (telnet, HTTP, the subnet sweep) use the default network, so a second, non-default
-      Wi-Fi would be a false positive for every caller here.
+      `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` — about the active network first, then
+      about every network. The question is unchanged from the old API; only the answer can no
+      longer be null. Checking *only* the active network was the first attempt and is wrong: a
+      Wi-Fi without internet (dead WAN, captive portal, an isolated AV network) stays connected
+      alongside cellular without being the default, and `AVRScanner.java:117` refuses the whole
+      scan on a `false`. `getAllNetworks()` is itself deprecated (API 31), which is why it is the
+      fallback rather than the whole answer — it goes when the `NetworkCallback` item below lands.
 
 ## Next platform deadline: targetSdk 37
 
@@ -40,10 +44,14 @@ blocks the current build, which is green.
       [CONNECTION.md](CONNECTION.md).
 - [ ] Same area, do it in one pass: `scan/WiFiInfo` still takes netmask and local IP for the sweep
       from `WifiManager.getDhcpInfo()`, deprecated since API 31 → `LinkProperties.getLinkAddresses()`
-      via `NetworkCapabilities`. The `getNetworkInfo(TYPE_WIFI)` half of this item is done, ahead of
-      the deadline and not by choice — it was crashing in the field, see *Broken today*. What is
-      still legacy about it is the trigger: the `WifiManager` broadcast, where a `NetworkCallback`
-      belongs.
+      and `getRoutes()`, via `ConnectivityManager.getLinkProperties(Network)`. The
+      `getNetworkInfo(TYPE_WIFI)` half of this item is done, ahead of the deadline and not by choice
+      — it was crashing in the field, see *Broken today*. Two things there are still legacy and want
+      the same pass: the trigger is a `WifiManager` broadcast where a `NetworkCallback` belongs, and
+      the fallback in `isWiFiConnected` uses `getAllNetworks()`, deprecated since API 31 as well. A
+      callback holding the current Wi-Fi `Network` would replace all three at once — and would hand
+      the scan and the sockets a `Network` to bind to, which is what the Local Network Protection
+      item above needs anyway.
 
 ## Structural
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,11 +22,15 @@ blocks the current build, which is green.
 - [x] Once both are done, drop `WRITE_EXTERNAL_STORAGE` from the manifest — it has been a no-op
       since Android 11.
 - [x] **`ConnectivityManager.getNetworkInfo(TYPE_WIFI)` returned null and killed the process.**
-      Play Console, 1.5.1 (versionCode 124), Pixel 8 Pro on Android 17 Beta: NPE in
-      `AVRApplication$1.onReceive` → `RuntimeException` out of `LoadedApk$ReceiverDispatcher`. The
-      deprecated overload returns null when no Wi-Fi network is connected — which is exactly the
-      state the `WifiManager` broadcast reports, so the receiver crashed on the event it exists to
-      handle. The lines were unchanged since the initial commit, so 1.6.0 was affected identically.
+      Play Console, 1.5.1 (versionCode 124), Pixel 8 Pro on Android 17 **Beta**: NPE in
+      `AVRApplication$1.onReceive` → `RuntimeException` out of `LoadedApk$ReceiverDispatcher`, which
+      takes the process with it. The lines were unchanged since the initial commit, so 1.6.0 was
+      affected identically. **The null itself did not reproduce** on a Pixel 8 with the finished
+      Android 17 (SDK 37) — not across three Wi-Fi off/on cycles, not in airplane mode, and not with
+      Data Saver on a metered Wi-Fi with the app in the background; the deprecated call returned an
+      object every time. So the triggering condition is still unknown: either a state those runs did
+      not hit, or beta behaviour that did not ship. Fixed anyway — the API is documented to be
+      allowed to return null, and nothing here may dereference it blindly.
       Both call sites now go through `WiFiInfo.isWiFiConnected(ConnectivityManager)`, which asks
       `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` — about the active network first, then
       about every network. The question is unchanged from the old API; only the answer can no

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,16 @@ blocks the current build, which is green.
       never having had a caller.
 - [x] Once both are done, drop `WRITE_EXTERNAL_STORAGE` from the manifest — it has been a no-op
       since Android 11.
+- [x] **`ConnectivityManager.getNetworkInfo(TYPE_WIFI)` returned null and killed the process.**
+      Play Console, 1.5.1 (versionCode 124), Pixel 8 Pro on Android 17 Beta: NPE in
+      `AVRApplication$1.onReceive` → `RuntimeException` out of `LoadedApk$ReceiverDispatcher`. The
+      deprecated overload returns null when no Wi-Fi network is connected — which is exactly the
+      state the `WifiManager` broadcast reports, so the receiver crashed on the event it exists to
+      handle. The lines were unchanged since the initial commit, so 1.6.0 was affected identically.
+      Both call sites now go through `WiFiInfo.isWiFiConnected(ConnectivityManager)`, which asks
+      `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` about the **active** network — unbound
+      sockets (telnet, HTTP, the subnet sweep) use the default network, so a second, non-default
+      Wi-Fi would be a false positive for every caller here.
 
 ## Next platform deadline: targetSdk 37
 
@@ -28,11 +38,12 @@ blocks the current build, which is green.
       core of this app: the subnet sweep in `scan/AVRScanner` and the raw sockets to the receiver.
       Needs the new local-network runtime permission and a rationale UI. Background:
       [CONNECTION.md](CONNECTION.md).
-- [ ] Same area, do it in one pass: `scan/WiFiInfo` relies on `WifiManager.getDhcpInfo()` (netmask
-      and local IP for the sweep) and `ConnectivityManager.getNetworkInfo(TYPE_WIFI)`, plus
-      `AVRApplication.java:63`. Both deprecated — `getDhcpInfo()` since API 31, the
-      `getNetworkInfo(int)` overload used here already since API 23 → `NetworkCallback` and
-      `NetworkCapabilities`.
+- [ ] Same area, do it in one pass: `scan/WiFiInfo` still takes netmask and local IP for the sweep
+      from `WifiManager.getDhcpInfo()`, deprecated since API 31 → `LinkProperties.getLinkAddresses()`
+      via `NetworkCapabilities`. The `getNetworkInfo(TYPE_WIFI)` half of this item is done, ahead of
+      the deadline and not by choice — it was crashing in the field, see *Broken today*. What is
+      still legacy about it is the trigger: the `WifiManager` broadcast, where a `NetworkCallback`
+      belongs.
 
 ## Structural
 

--- a/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
+++ b/app/src/main/java/de/pskiwi/avrremote/AVRApplication.java
@@ -54,6 +54,7 @@ import de.pskiwi.avrremote.log.LogMode;
 import de.pskiwi.avrremote.log.Logger;
 import de.pskiwi.avrremote.log.SDLogger;
 import de.pskiwi.avrremote.models.ModelConfigurator;
+import de.pskiwi.avrremote.scan.WiFiInfo;
 
 /** Global State */
 public final class AVRApplication extends Application {
@@ -62,8 +63,8 @@ public final class AVRApplication extends Application {
 
 		public void onReceive(Context context, Intent intent) {
 			Logger.info("Broadcast " + intent);
-			final boolean newConnected = connectivityManager.getNetworkInfo(
-					ConnectivityManager.TYPE_WIFI).isConnected();
+			final boolean newConnected = WiFiInfo
+					.isWiFiConnected(connectivityManager);
 			enableManager.setStatus(StatusFlag.WLAN, newConnected);
 			Logger.info("AVRApplication.Wifi connected:" + newConnected + " "
 					+ activeHandler + " " + enableManager);

--- a/app/src/main/java/de/pskiwi/avrremote/scan/WiFiInfo.java
+++ b/app/src/main/java/de/pskiwi/avrremote/scan/WiFiInfo.java
@@ -22,6 +22,8 @@ import java.net.InetAddress;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.DhcpInfo;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.wifi.WifiManager;
 import de.pskiwi.avrremote.log.Logger;
 
@@ -45,8 +47,32 @@ public class WiFiInfo {
 	}
 
 	private boolean isWiFiConnected() {
-		return connectivity.getNetworkInfo(ConnectivityManager.TYPE_WIFI)
-				.isConnected();
+		return isWiFiConnected(connectivity);
+	}
+
+	/**
+	 * Ist das aktive Netz ein WLAN?
+	 *
+	 * Ersetzt getNetworkInfo(TYPE_WIFI).isConnected(): der Aufruf ist seit API
+	 * 23 deprecated und liefert null, sobald kein WLAN verbunden ist — genau
+	 * dann, wenn der WifiManager-Broadcast eintrifft. In AVRApplication.onReceive
+	 * hat das den Prozess mitgenommen (Play Console, 1.5.1, Android 17).
+	 *
+	 * Gefragt wird nach dem *aktiven* Netz, nicht nach irgendeinem verbundenen
+	 * WLAN: Sockets ohne Network-Bindung — Telnet, HTTP und der Subnetz-Scan —
+	 * gehen über das Default-Netz, ein daneben verbundenes WLAN nützt ihnen
+	 * nichts.
+	 */
+	public static boolean isWiFiConnected(ConnectivityManager connectivity) {
+		final Network network = connectivity.getActiveNetwork();
+		if (network == null) {
+			return false;
+		}
+		final NetworkCapabilities capabilities = connectivity
+				.getNetworkCapabilities(network);
+		return capabilities != null
+				&& capabilities
+						.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
 	}
 
 	public String getErrorCause() {

--- a/app/src/main/java/de/pskiwi/avrremote/scan/WiFiInfo.java
+++ b/app/src/main/java/de/pskiwi/avrremote/scan/WiFiInfo.java
@@ -54,11 +54,16 @@ public class WiFiInfo {
 	 * Ist ein WLAN verbunden ?
 	 *
 	 * Ersetzt getNetworkInfo(TYPE_WIFI).isConnected(): der Aufruf ist seit API
-	 * 23 deprecated und liefert null, sobald kein WLAN verbunden ist - also
-	 * genau in dem Zustand, den der WifiManager-Broadcast meldet. In
-	 * AVRApplication.onReceive hat das den Prozess mitgenommen (Play Console,
-	 * 1.5.1, Android 17). Die Frage bleibt dieselbe wie vorher, nur die Antwort
-	 * kommt aus NetworkCapabilities und kann nicht mehr null sein.
+	 * 23 deprecated und darf null liefern. In AVRApplication.onReceive hat er
+	 * das getan und den Prozess mitgenommen (Play Console, 1.5.1, Pixel 8 Pro,
+	 * Android 17 *Beta*). Unter welcher Bedingung, ist offen - auf einem Pixel 8
+	 * mit dem fertigen Android 17 war es nicht zu reproduzieren: nicht beim
+	 * WLAN-Toggle, nicht im Flugmodus, nicht mit Data Saver auf einem metered
+	 * WLAN im Hintergrund. Dort kam immer ein Objekt zurück. Also entweder ein
+	 * Zustand, den diese Tests nicht getroffen haben, oder Beta-Verhalten, das
+	 * es nicht ins Release geschafft hat. Die Frage bleibt hier dieselbe wie
+	 * vorher, nur die Antwort kommt aus NetworkCapabilities und kann nicht null
+	 * sein.
 	 *
 	 * Zuerst das aktive Netz, weil das der Normalfall ist und getActiveNetwork()
 	 * als einziger der beiden Aufrufe nicht deprecated ist. Der Fallback ist

--- a/app/src/main/java/de/pskiwi/avrremote/scan/WiFiInfo.java
+++ b/app/src/main/java/de/pskiwi/avrremote/scan/WiFiInfo.java
@@ -51,20 +51,41 @@ public class WiFiInfo {
 	}
 
 	/**
-	 * Ist das aktive Netz ein WLAN?
+	 * Ist ein WLAN verbunden ?
 	 *
 	 * Ersetzt getNetworkInfo(TYPE_WIFI).isConnected(): der Aufruf ist seit API
-	 * 23 deprecated und liefert null, sobald kein WLAN verbunden ist — genau
-	 * dann, wenn der WifiManager-Broadcast eintrifft. In AVRApplication.onReceive
-	 * hat das den Prozess mitgenommen (Play Console, 1.5.1, Android 17).
+	 * 23 deprecated und liefert null, sobald kein WLAN verbunden ist - also
+	 * genau in dem Zustand, den der WifiManager-Broadcast meldet. In
+	 * AVRApplication.onReceive hat das den Prozess mitgenommen (Play Console,
+	 * 1.5.1, Android 17). Die Frage bleibt dieselbe wie vorher, nur die Antwort
+	 * kommt aus NetworkCapabilities und kann nicht mehr null sein.
 	 *
-	 * Gefragt wird nach dem *aktiven* Netz, nicht nach irgendeinem verbundenen
-	 * WLAN: Sockets ohne Network-Bindung — Telnet, HTTP und der Subnetz-Scan —
-	 * gehen über das Default-Netz, ein daneben verbundenes WLAN nützt ihnen
-	 * nichts.
+	 * Zuerst das aktive Netz, weil das der Normalfall ist und getActiveNetwork()
+	 * als einziger der beiden Aufrufe nicht deprecated ist. Der Fallback ist
+	 * aber nicht optional: ein WLAN ohne Internet - Router mit totem WAN,
+	 * Captive Portal, bewusst isoliertes AV-Netz - bleibt neben aktivem
+	 * Mobilfunk verbunden, ohne Default-Netz zu sein. Der Receiver ist dann
+	 * trotzdem da, und AVRScanner.scan() verweigert bei "false" den Suchlauf
+	 * komplett.
+	 *
+	 * Achtung beim Lesen eines Logs: getActiveNetwork() liefert auch dann null,
+	 * wenn dem Prozess der Netzzugriff entzogen wurde (Data Saver, App-Standby),
+	 * nicht nur wenn kein Netz da ist.
 	 */
 	public static boolean isWiFiConnected(ConnectivityManager connectivity) {
-		final Network network = connectivity.getActiveNetwork();
+		if (isWiFi(connectivity, connectivity.getActiveNetwork())) {
+			return true;
+		}
+		for (Network network : connectivity.getAllNetworks()) {
+			if (isWiFi(connectivity, network)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isWiFi(ConnectivityManager connectivity,
+			Network network) {
 		if (network == null) {
 			return false;
 		}


### PR DESCRIPTION
## Der Absturz

Play Console, Version 124 (1.5.1), Pixel 8 Pro auf **Android 17 Beta**:

```
java.lang.RuntimeException
  at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0
Caused by java.lang.NullPointerException: Attempt to invoke virtual method
  'boolean android.net.NetworkInfo.isConnected()' on a null object reference
  at de.pskiwi.avrremote.AVRApplication$1.onReceive (AVRApplication.java:64)
```

Da der Receiver im `Application`-Kontext läuft, nimmt die Exception den ganzen Prozess mit. Die betroffenen Zeilen sind seit dem initial commit unverändert — 1.6.0 hat exakt denselben Code.

`ConnectivityManager.getNetworkInfo(int)` ist seit API 23 deprecated und darf `null` liefern; der Code dereferenziert ohne Prüfung. Dasselbe Muster stand ein zweites Mal in `scan/WiFiInfo.java:48`, direkt vor dem Subnetz-Scan.

## Was der Gerätetest ergab

Pixel 8, **fertiges Android 17** (SDK 37), Debug-Builds von `master` und diesem Branch, über adb gefahren.

`master`, also ungefixt: ~40 Broadcasts über drei WLAN-Aus/An-Zyklen, dazu ein Flugmodus-Zyklus und ein Durchlauf mit Data Saver + metered WLAN + App im Hintergrund — **kein Absturz**. Die deprecated API lieferte jedes Mal ein Objekt, auch bei ausgeschaltetem WLAN.

**Die auslösende Bedingung ist damit weiter unbekannt.** Entweder ein Zustand, den diese Läufe nicht getroffen haben, oder Beta-Verhalten, das es nicht ins Release geschafft hat. Der Fix bleibt trotzdem richtig: die API darf laut Doku `null` liefern, und hier wurde ungeprüft dereferenziert.

Dieser Branch über dieselben Zyklen: korrekte `true`/`false`-Übergänge im Log, kein Absturz.

## Fix

Beide Stellen gehen über `WiFiInfo.isWiFiConnected(ConnectivityManager)`, das `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` fragt — erst das aktive Netz, dann alle. Die Frage bleibt dieselbe wie bei der alten API, nur die Antwort kann nicht mehr `null` sein. Beide APIs liegen unter minSdk 24, `ACCESS_NETWORK_STATE` steht im Manifest.

### Warum nicht nur das aktive Netz (Commit 2)

Der erste Anlauf prüfte nur `getActiveNetwork()`. Das verengt das Prädikat dort, wo es weh tut: ein WLAN **ohne Internet** — toter WAN-Link, Captive Portal, isoliertes AV-Netz — bleibt neben aktivem Mobilfunk verbunden, ohne Default-Netz zu sein.

| Konsument | Kosten eines falschen `false` |
|---|---|
| `StatusFlag.WLAN` | gering — `default:`-Zweig in `EnableManager`, keine Kaskade, keine View am Flag |
| `triggerReconnect()` entfällt | begrenzt — der Backoff im `ResilentConnector` fängt es |
| `alertNoWLan()` | nur nach gescheitertem Connect erreichbar → falscher Text, kein falscher Zustand |
| **`AVRScanner.scan()`** | **der reale Verlust** — `AVRScanner.java:117` ist ein hartes Gate, der Auto-Scan wird komplett verweigert |

`getAllNetworks()` ist seit API 31 selbst deprecated — deshalb Fallback und nicht die ganze Antwort; es geht mit dem `NetworkCallback`-Umbau.

**Ungetestet, mangels passendem Router:** genau dieser Fall — WLAN ohne Internet bei aktivem Mobilfunk.

## Nicht Teil dieses PRs

- **Kein Version-Bump.** 1.6.0 ist getaggt und ausgeliefert; für den Fix braucht es 126/1.6.1 plus `assets/whatsnew.html` (RELEASE.md).
- **`WifiManager.getDhcpInfo()` bleibt.** Der unbewachte Deref in `getNetmask()` ist erreichbar (`AVRScanner.java:129`), kann den Prozess aber nicht killen — beide Einstiegspunkte fangen `Exception`. Bleibt beim targetSdk-37-Item.
- **Der `WifiManager`-Broadcast bleibt.** Ein `NetworkCallback` ersetzt Trigger, `getAllNetworks()` und `getDhcpInfo()` in einem Zug — und liefert das `Network` zum Binden, das Local Network Protection ohnehin braucht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJYiak7auvjb2n6eZMJvzf