### PR TITLE
TODO.md: drop everything done, keep what live items still need

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Android remote control for Denon and Marantz AV receivers (`de.pskiwi.avrremote`, GPL v3).
 Talks to receivers on the local network — there is no backend and no account.
 
-**[TODO.md](TODO.md) is the backlog** — known-broken behaviour, the next platform deadline, and the
-housekeeping items, each with file and line. Read it before proposing work of your own; what looks
+**[TODO.md](TODO.md) is the backlog** — the next platform deadline, the structural items and the
+housekeeping, each with file and line. Read it before proposing work of your own; what looks
 like an oversight is usually already listed there with the reason it was left alone. When you finish
-one of the items, tick its checkbox in the same commit.
+an item, **delete it** in the same commit rather than ticking it — the file only stays readable
+because closed items do not accumulate, and the git history is where "what was done and why" lives.
+If a closed item established something a live item still relies on, fold that into the live item.
 
 **[CONNECTION.md](CONNECTION.md) is the reference for everything network-facing** — the two
 transports, the reconnect loop and its generation counter, who decides when to hang up, and what
@@ -185,11 +187,9 @@ Consequences:
   — Java 11 syntax only.
 - **Within Java 11, write modern Java.** The code dates from 2010 and mostly predates it, but new and
   touched code should not imitate that. In particular use **try-with-resources** rather than the
-  manual `try { … } finally { x.close(); }` pattern — `http/HTTPSupport` is the reference. The old
-  pattern survives in a dozen places (inventory in [TODO.md](TODO.md)); converting one is welcome
-  when you are editing that code anyway, but do not sweep the tree as a
-  side errand — and note `core/Connector.java:168` is not convertible at all, it closes the socket
-  only on the failure path (`if (!ok)`). The other reason to keep the manual form is when
+  manual `try { … } finally { x.close(); }` pattern — `http/HTTPSupport` is the reference. The tree
+  was converted in August 2026 and `core/Connector.java:168` is the only manual block left: it is
+  not convertible at all, it closes the socket only on the failure path (`if (!ok)`). The other reason to keep the manual form is when
   an exception from `close()` must be swallowed deliberately — see
   `HTTPSupportTest.serveOneRequest`, where letting it propagate would fake a test failure.
   This does **not** extend to the UI bases above: those are a migration, not a style choice.
@@ -213,8 +213,7 @@ Three things are easy to forget and all are required at `targetSdk 36`:
 3. If the activity requests a runtime permission, gate the request on
    `savedInstanceState == null` — these activities are recreated on every rotation.
 
-## Known-broken, and what comes next
+## What comes next
 
-Both live in [TODO.md](TODO.md): behaviour that is already broken and predates the SDK 36 upgrade
-(do not report it as a regression), and the next platform deadline, Local Network Protection at
-Android 17. The connection side of that deadline is in [CONNECTION.md](CONNECTION.md).
+The next platform deadline is Local Network Protection at Android 17, and it is the first item in
+[TODO.md](TODO.md). The connection side of it is in [CONNECTION.md](CONNECTION.md).

--- a/CONNECTION.md
+++ b/CONNECTION.md
@@ -161,12 +161,13 @@ process had survived — `openend at` appears only at the app's own restart.
 greyed out until a receiver is actually connected — worth knowing when testing without hardware.
 
 The flags are not independent. `setStatus()` cascades through a deliberate `switch` fallthrough:
-clearing `Reachable` also clears `Connected`, `Power` and zones 1–3. **One missed ping response
+clearing `Reachable` also clears `Connected`, `Power` and all four zones. **One missed ping response
 greys out nearly the whole UI** — which is what makes the `PING_TIMEOUT` observation above more than
 cosmetic. Setting cascades the other way: `Power` implies `Connected` implies `Reachable`.
 
-`Zone4` is missing from that reset — see [TODO.md](TODO.md). It is a real flag with a real zone
-behind it, so on a four-zone receiver those controls stay enabled after the connection drops.
+`Zone4` was missing from that reset until August 2026, so on a four-zone receiver — `AVR5308`,
+`AVR4308`, `AVR4810`, `AVR5805` — those controls stayed enabled after the connection dropped while
+zones 1–3 greyed out. Worth knowing when reading an older log.
 
 ## Reading a log
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -87,7 +87,8 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
      The 1.6.0 replacement of Apache HttpClient could only be tested against the hardware that was
      available; a user on an untested model needs to know that a missing input name is worth
      reporting.
-3. **Tick the items** in [TODO.md](TODO.md) that this release closes.
+3. **Remove the items** in [TODO.md](TODO.md) that this release closes — that file records open work
+   only, the history records what was done.
 4. **Commit, tag, push.** The tag convention is `v<versionName>`:
 
    ```sh

--- a/TODO.md
+++ b/TODO.md
@@ -1,44 +1,12 @@
 # TODO
 
 Things worth doing, roughly in the order they will hurt if left alone.
-Everything here was found while moving the build to SDK 36 in July 2026; none of it
+Most of it was found while moving the build to SDK 36 in July 2026; none of it
 blocks the current build, which is green.
 
-## Broken today
-
-- [x] **Sending logs does not work.** `SDLogger.getLogURI()` returned a `file://` URI which
-      `log/FeedbackReporter` put into `Intent.EXTRA_STREAM` → `FileUriExposedException` since
-      targetSdk 24. Now handed out as a content URI by `log/LogFileProvider`, with
-      `FLAG_GRANT_READ_URI_PERMISSION` on the intent. The provider is written by hand rather than
-      derived from `androidx.core`: the project has no dependencies (CLAUDE.md), and there is no
-      platform `FileProvider` at any API level to fall back to — the class has only ever existed in
-      the support library and AndroidX. It serves exactly one file name from the log directory,
-      read-only, and is `exported="false"`.
-- [x] **`SDLogger` writes to `Environment.getExternalStorageDirectory()`**, which fails under
-      scoped storage (Android 10+). Moved to `getExternalFilesDir(null)`, falling back to
-      `getFilesDir()`. The `MEDIA_MOUNTED`/`MEDIA_REMOVED` receiver went with it — an app-specific
-      directory is always there — which also fixes the leak from `stopWatchingExternalStorage()`
-      never having had a caller.
-- [x] Once both are done, drop `WRITE_EXTERNAL_STORAGE` from the manifest — it has been a no-op
-      since Android 11.
-- [x] **`ConnectivityManager.getNetworkInfo(TYPE_WIFI)` returned null and killed the process.**
-      Play Console, 1.5.1 (versionCode 124), Pixel 8 Pro on Android 17 **Beta**: NPE in
-      `AVRApplication$1.onReceive` → `RuntimeException` out of `LoadedApk$ReceiverDispatcher`, which
-      takes the process with it. The lines were unchanged since the initial commit, so 1.6.0 was
-      affected identically. **The null itself did not reproduce** on a Pixel 8 with the finished
-      Android 17 (SDK 37) — not across three Wi-Fi off/on cycles, not in airplane mode, and not with
-      Data Saver on a metered Wi-Fi with the app in the background; the deprecated call returned an
-      object every time. So the triggering condition is still unknown: either a state those runs did
-      not hit, or beta behaviour that did not ship. Fixed anyway — the API is documented to be
-      allowed to return null, and nothing here may dereference it blindly.
-      Both call sites now go through `WiFiInfo.isWiFiConnected(ConnectivityManager)`, which asks
-      `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` — about the active network first, then
-      about every network. The question is unchanged from the old API; only the answer can no
-      longer be null. Checking *only* the active network was the first attempt and is wrong: a
-      Wi-Fi without internet (dead WAN, captive portal, an isolated AV network) stays connected
-      alongside cellular without being the default, and `AVRScanner.java:117` refuses the whole
-      scan on a `false`. `getAllNetworks()` is itself deprecated (API 31), which is why it is the
-      fallback rather than the whole answer — it goes when the `NetworkCallback` item below lands.
+Finished items are removed rather than ticked — the git history holds what was done and why, and
+this file stayed readable only by not accumulating them. What a closed item established and a live
+one still depends on has been folded into the live one.
 
 ## Next platform deadline: targetSdk 37
 
@@ -46,36 +14,35 @@ blocks the current build, which is green.
       core of this app: the subnet sweep in `scan/AVRScanner` and the raw sockets to the receiver.
       Needs the new local-network runtime permission and a rationale UI. Background:
       [CONNECTION.md](CONNECTION.md).
-- [ ] Same area, do it in one pass: `scan/WiFiInfo` still takes netmask and local IP for the sweep
-      from `WifiManager.getDhcpInfo()`, deprecated since API 31 → `LinkProperties.getLinkAddresses()`
-      and `getRoutes()`, via `ConnectivityManager.getLinkProperties(Network)`. The
-      `getNetworkInfo(TYPE_WIFI)` half of this item is done, ahead of the deadline and not by choice
-      — it was crashing in the field, see *Broken today*. Two things there are still legacy and want
-      the same pass: the trigger is a `WifiManager` broadcast where a `NetworkCallback` belongs, and
-      the fallback in `isWiFiConnected` uses `getAllNetworks()`, deprecated since API 31 as well. A
-      callback holding the current Wi-Fi `Network` would replace all three at once — and would hand
-      the scan and the sockets a `Network` to bind to, which is what the Local Network Protection
-      item above needs anyway.
+- [ ] Same area, do it in one pass: everything network-facing in `scan/WiFiInfo` and
+      `AVRApplication` is still on legacy API.
+      - `WifiManager.getDhcpInfo()` gives netmask and local IP for the sweep. Deprecated since API
+        31 → `LinkProperties.getLinkAddresses()` and `getRoutes()`, via
+        `ConnectivityManager.getLinkProperties(Network)`.
+      - The trigger is a `WifiManager` broadcast where a `NetworkCallback` belongs.
+      - `WiFiInfo.isWiFiConnected()` asks `NetworkCapabilities.hasTransport(TRANSPORT_WIFI)` about
+        the active network first and then about every network, via `getAllNetworks()` — itself
+        deprecated since API 31. The two-step is deliberate and any rewrite has to keep the
+        property: a Wi-Fi without internet (dead WAN, captive portal, an isolated AV network) stays
+        connected alongside cellular without being the default network, and `AVRScanner.java:117`
+        refuses the whole scan on a `false`. Checking only the active network was tried and is
+        wrong for exactly that case.
+
+      A callback holding the current Wi-Fi `Network` replaces all three at once — and hands the
+      scan and the sockets a `Network` to bind to, which is what Local Network Protection needs
+      anyway. That is why this is one item and not three.
+- [ ] Watch for another NPE in `AVRApplication$1.onReceive`. The one that came in from the field
+      (1.5.1, Pixel 8 Pro, Android 17 **Beta**) was `getNetworkInfo(TYPE_WIFI)` returning null, and
+      it is fixed; but the null could not be reproduced on a Pixel 8 with the finished Android 17 —
+      not across three Wi-Fi off/on cycles, not in airplane mode, not with Data Saver on a metered
+      Wi-Fi with the app backgrounded. So the trigger is still unknown, and the working theory is
+      that it was beta-only. A second report would disprove that and mean something else is wrong.
 
 ## Structural
 
-- [x] **Test coverage was three files.** `http/HTTPSupportTest`, `http/Series08ParserTest` and
-      `http/AVRXMLInfoParserTest` (added with the Apache removal) set up `src/test` and the JUnit
-      dependency; everything else is still uncovered. The highest-value test to add next is one for `models/ModelConfigurator`, because it
-      covers a failure mode the compiler cannot see: it resolves the 60 receiver classes **by
-      reflection** from a preference string (`"AVR-3310"` → `AVR3310`). Rename a class or let an
-      entry in `res/values/lists.xml` drift and there is no build error — the app silently falls
-      back to `AVRGeneric` and the user just misses features. A JVM unit test that runs all 60
-      entries of `@array/modelNames` through the same normalisation and instantiates them catches
-      exactly that. Both sides hold 60 entries today, so the test starts green.
-      → `models/ModelConfiguratorTest` does this in both directions (name → class, and every
-      concrete `IAVRModel` has a list entry). The reflection moved out of `update()` into
-      `ModelConfigurator.createModel(String)`, which is what the test drives; the dash and
-      `(experimental)` stripping is deliberately spelled out a second time in the test, so that
-      changing the convention shows up as a failure. `lists.xml` is declared as a test input in
-      `app/build.gradle`, otherwise Gradle skips the test on exactly the change it guards.
-- [ ] After that, `models/` (pure capability logic) and `core/ZoneState.java` (1237 lines) are the
-      cheapest places to add coverage.
+- [ ] **Test coverage is six JVM classes and no instrumentation tests.** The cheapest places to add
+      more are `models/` (pure capability logic, no Android types) and `core/ZoneState.java`
+      (1237 lines).
 - [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and
       `endElement` read `localName`, which a standard `SAXParserFactory` leaves empty because it is
       not namespace-aware by default — on a JVM the parser silently collects nothing. Android's
@@ -83,35 +50,26 @@ blocks the current build, which is green.
       Falling back to `qName` when `localName` is empty would make the parser portable and testable.
       `core/RenameService.java:109` has the same pattern and would need the same fix; the
       `Series08*Parser` classes are unaffected, they read with `BufferedReader` and regexes.
+      Whoever writes that test will also trip over the XXE hardening in the same parser: on a plain
+      JVM it now rejects **any** XML carrying a DOCTYPE, because `disallow-doctype-decl` applies
+      there and on Android it does not (see CLAUDE.md). Receivers never send one, so nothing breaks
+      in the app.
 - [ ] **Nothing in the 2008-series path was verified against hardware.** The Apache removal touched
       all of it and none of it could be exercised — no such receiver was available. Affected:
-      `http/Series08Reader` (the cookie store it now clears per run, and the `r_option1.asp` →
+      `http/Series08Reader` (the cookie store it clears per run, and the `r_option1.asp` →
       `d_option1.asp` sequence that depends on shared session state), plus
       `http/Series08ZoneRenameParser` and `http/Series08QuickSelectParser`, whose `OPTION_PATTERN`
       went from `matches()` with a wrapping `.*` to `find()` in a loop. `http/Series08ParserTest`
       pins the behaviour that could have broken — notably that the **last** match in a line wins,
       not the first, which is what the old greedy `.*` did — but those tests were written from the
-      code, not from a real page. One run against a 2008-series receiver settles it: check that
-      input names, zone names and quick-select names all still appear.
-- [x] Same area, latent NPE: `Series08Reader` has no length check on the response body where
-      `AVRHTTPClient` has one. `Series08InputParser.findLine` returns null when the marker line is
-      missing and the constructor then runs `OPTION_PATTERN.matcher(null)`. An empty or 404 answer
-      triggers it. Pre-existing rather than a regression — but the Apache removal made the asymmetry
-      between the two readers visible, and only one side got the guard.
-      → The constructor now falls back to `""`, so a missing marker yields an empty input list
-      instead of a crash. Deliberately not the length check `AVRHTTPClient` has: that one rejects a
-      short body outright, whereas here an unparseable page and a page with no inputs are the same
-      answer to the caller. Still unverified against a 2008-series receiver, like everything else
-      in this path.
+      code, not from a real page. The empty-page guard in `Series08InputParser` is unverified for
+      the same reason. One run against a 2008-series receiver settles all of it: check that input
+      names, zone names and quick-select names all still appear.
 - [ ] Same area, cookie lifetime: the store is cleared per Series08 read
       (`Series08Reader.readSeries08Info`), whereas the old `DefaultHttpClient` was per
       `AVRHTTPClient` instance, so it also covered the multi-zone path. Exact parity would clear it
       in the `AVRHTTPClient` constructor. Every receiver tested sends no `Set-Cookie` at all, so
       this only matters if a 2008-series device turns out to use sessions.
-- [ ] Side effect of the XXE hardening in `http/AVRXMLInfoParser`: on a plain JVM the parser now
-      rejects **any** XML carrying a DOCTYPE, because `disallow-doctype-decl` applies there (on
-      Android it does not — see CLAUDE.md). Receivers never send one, so nothing breaks in the app,
-      but whoever adds the JVM test the item above asks for will trip over it.
 - [ ] **`NetDisplay.doHTTPMove()` and `doHTTPSeries08Move()` are unreachable.**
       `AbstractModel:135` returns `DisplayMoveMode.Classic` and not one of the 60 model classes
       overrides `getDisplayMoveMode()`, so the `switch` in `ScreenMover` always takes the `default`
@@ -120,57 +78,17 @@ blocks the current build, which is green.
 - [ ] **The receiver connection lives on a daemon thread owned by `AVRApplication`, not a Service.**
       A design decision from 2010. Under modern background restrictions the process can be reclaimed
       and the connection dies with it. Note that the one "app does not reconnect after standby"
-      report we have a log for was *not* this — the process had survived; it was the stale-teardown
-      race in the item below. How the loop works today: [CONNECTION.md](CONNECTION.md).
-- [x] `ActiveHandler.contextResumed()` → `forceReconnect()` → `ResilentConnector.stopConnector()`
-      runs on the UI thread and waited there for the old reconnect thread — a full second whenever
-      that thread sat in `checkAddress()`, because neither `InetAddress.isReachable()` nor the
-      `testPort()` connects react to `interrupt()`. The wait bought nothing either: it timed out and
-      the code carried on with the thread still alive. `ThreadHandler.stop()` now interrupts and
-      returns. What the `join` *did* cover by accident was a detached thread that came back inside
-      that second: its stale writes then landed before `closeCurrentConnection()`, which cleaned up
-      after them. So the same change had to make `Reconnector.run()` consult `generation` before
-      every write to shared state, and `publishConnector()` makes that check atomic against the
-      cleanup — a check-then-assign only narrows the window. `core/ThreadHandlerTest` pins the
-      timing (the case fails at ~1000 ms against the old implementation) but reaches none of that
-      second half. Flagged in PR #13 review, predates that PR.
-- [x] Teardown deferred by Doze stops the connection right after resume, leaving no reconnect loop
-      at all until the app is killed and restarted. The `ACTION_SCREEN_OFF` receiver in
-      `AVRApplication` is gone — `ActiveHandler` is now the only owner of the disconnect policy, so
-      the connection drops after the user's auto-disconnect timeout instead of immediately on
-      screen-off. On the timer path `StopConnectorTask.run()` skips the stop when an activity is
-      active again (`cancelCurrentTask()` only wins that race sometimes) and, because that check is
-      not atomic against a resume landing right after it, reconnects itself if one did.
-- [x] **`ResilentConnector.connectionConfig` is a plain field read across threads.** Written on the
-      UI thread in `reconfigure()` and `forceReconnect()`, read by every reconnect thread — the
-      `checkAddress()` calls and half the log lines in `Reconnector.run()`. Without `volatile` there
-      is no guarantee a running thread ever sees a new address, so after an IP change the old thread
-      can keep dialling the old receiver until it exits on its own. Never observed; the threads are
-      short-lived and `stopConnector()` interrupts them anyway, which is probably why it has never
-      surfaced. One keyword to fix. Left alone in the PR that removed the `join`, because that PR
-      had no business touching it — but note the same PR made concurrent readers *certain* rather
-      than occasional, so the odds moved. → `volatile`, with the reason in a comment at the field.
+      report we have a log for was *not* this — the process had survived; it was a stale-teardown
+      race between `ActiveHandler.contextResumed()` and the reconnect thread, fixed since. How the
+      loop works today: [CONNECTION.md](CONNECTION.md).
 - [ ] **`EnableManager.setStatus()` is an unsynchronised read-modify-write.** It copies
       `connectionStatus`, mutates it through the deliberate `switch` fallthrough, compares and fires
-      the listeners (`EnableManager.java:109`). Callers now include the UI thread, the
+      the listeners (`EnableManager.java:109`). Callers include the UI thread, the
       `StopConnector-Timer` thread and one or more reconnect threads at the same time. Two
       overlapping calls can lose a flag or fire listeners with a half-built status, which surfaces
       as buttons that stay greyed out until the next status change repairs them. Cheaper to fix than
       it looks: `fireListener()` only copies the status and `Handler.post()`s it, so a `synchronized`
       on `setStatus()` would cover a few field writes and a post, never the UI fanout itself.
-- [x] **`EnableManager.setStatus()` forgets `Zone4` when it clears.** The `Power` case of the
-      remove-fallthrough resets `Zone1`, `Zone2` and `Zone3` and stops there
-      (`EnableManager.java:131-136`), but `Zone4` is a real flag with a real zone behind it
-      (`core/Zone.java:25`). On a four-zone receiver its controls therefore stay enabled after the
-      connection drops, while zones 1–3 grey out — so it is visibly inconsistent, not just
-      theoretical. One line, but check first whether any four-zone model is actually reachable in
-      `@array/modelNames` before calling it user-visible.
-      → It is: `AVR5308`, `AVR4308`, `AVR4810` and `AVR5805` return 4 from `getZoneCount()`, and
-      `ModelConfiguratorTest` pins every model class to a `@array/modelNames` entry, so all four are
-      selectable. User-visible, therefore, and now one `reset(StatusFlag.Zone4)` longer.
-- [x] `ResilentConnector.java:159` logs `Reconnector:Reconnector:connection to [...] closed` — the
-      prefix is doubled. Cosmetic, but anyone grepping a log against
-      [CONNECTION.md](CONNECTION.md) trips over it.
 - [ ] **`AVRTargetTester.PING_TIMEOUT` is 250 ms, which a phone waking from standby cannot meet.**
       Wi-Fi power save puts the receiver out of reach for the first moments after the user picks the
       phone up, so `checkAddress()` reports "not reachable" for a device that is plainly there — the
@@ -179,106 +97,49 @@ blocks the current build, which is green.
       measuring before changing: `scan/AVRScanner` uses the same constant for its subnet sweep, and
       raising it there costs scan time, so the two uses probably want separate values.
 
-## Time bomb, no fuse length known
-
-- [x] **Apache HTTP** in `http/AVRHTTPClient`, `http/Series08Reader` and `core/display/NetDisplay`
-      (26 `org.apache.http` imports across the three). Replaced by `http/HTTPSupport` on
-      `HttpURLConnection`; `useLibrary` and the manifest `<uses-library>` are gone, so the app no
-      longer depends on Google keeping the optional platform library around.
-
 ## Housekeeping
 
-- [x] **Gradle 10 syntax**: `./gradlew --warning-mode all` flags exactly two spots —
-      `namespace "…"` and `abortOnError false` need `=` assignment. Two characters.
-- [x] `versionCode` and `versionName` sat in the manifest unchanged since Nov 2020 and had to be
-      raised before any release. Now 125 / 1.6.0, with a matching block in `assets/whatsnew.html` —
-      without the `versionCode` bump the release notes never open, `AVRSettings.isShowChangeLog()`
-      compares it against the `AVRLastVersionCode` preference. The whole procedure is written down
-      in [RELEASE.md](RELEASE.md) now.
-- [x] **12 manual `try { … } finally { close(); }` blocks left** in `core/Connector`,
-      `core/MacroManager`, `core/RenameService`, `scan/AVRTargetTester`, the three
-      `http/Series08*Parser` and `log/FeedbackReporter`. try-with-resources is the
-      convention now (see CLAUDE.md); `http/HTTPSupport` is the reference.
-      → All converted except `core/Connector.java:168`, which CLAUDE.md already flags as not
-      convertible — it closes the socket only on the failure path. Two of them were doing slightly
-      less than they looked: `MacroManager.doSave()` wrote its `# saved` header *before* the inner
-      try, and `FeedbackReporter.saveCrash()` logged before it, so a throw there leaked the stream.
-      Both now open inside the resource block. Note on `Connector.close()`: `try (socket)` on the
-      final *field* is legal — JLS 14.20.3 allows a field access as a resource, not just a local —
-      so no helper variable is needed. One behaviour detail there, harmless but worth knowing when
-      reading a log: a throwing `close()` used to *replace* the shutdown exception, and is now
-      suppressed under it, while the handler logs only `e.toString()`. A close failure that
-      coincides with a shutdown failure therefore no longer shows up.
-- [x] `misc/add-copyright.sh` still uses the pre-Gradle path (`../src/**/*.java` instead of
-      `app/src/main/...`), so it currently matches nothing.
-      → Deleted instead of fixed; it is not needed any more. Worth recording what the attempted fix
-      turned up, because the same trap sits in any script here: the path was only half the problem.
-      `shopt -s globstar` does not exist in bash 3.2, which is what macOS ships, and there `**`
-      collapses to one directory level. And the header check `grep -q '* Copyright …'` relies on a
-      leading `*` being a literal — true for GNU and BSD grep, but `ugrep` rejects it as an empty
-      expression and fails *every* file. Once the glob was fixed, that combination would have
-      prepended the licence header to all 168 files a second time. `misc/file-copyright.txt` was
-      the script's input and is now referenced by nothing.
-- [x] `misc/createicons.sh` looks obsolete and should probably just be deleted: it writes 46 plain
-      red placeholder squares (`convert -size 32x32 canvas:red …`) to `res/...` relative to the
-      **current** directory. Run from `misc/` or the repo root it only creates a stray `res/` tree;
-      run from `app/src/main` it would overwrite the real icons with red squares. `misc/mkicons.sh`
-      is the maintained script and already uses the Gradle path (`TGT=../app/src/main/res`).
-      → Deleted.
-- [x] **Play-Store icon still showed the old 2010 raster.** The 512×512 export now exists as
-      `misc/play-store-icon-512.png`, rendered from `misc/play-store-icon.svg` — the same artwork as
-      `assets/icon.svg` plus a black `<rect>` covering the full viewBox, so the corners the round
-      chassis leaves open are filled rather than transparent. The claim that nothing in-tree can
-      rasterize was half right: `magick`, `rsvg-convert` and `inkscape` are all absent, but macOS
-      ships `qlmanage`, and `qlmanage -t -s 512` renders the SVG faithfully (command recorded in a
-      comment at the top of the SVG). The artwork now has **four** copies that have to move together
-      — `res/drawable/ic_launcher_foreground.xml` (plus its API 24/25 twin in `mipmap-anydpi/`),
-      `assets/icon.svg`, `docs/avr-icon.svg` (byte-identical to the latter, feeds the GitHub Pages
-      site) and `misc/play-store-icon.svg`. Deduplicating them would be worth more than the fourth
-      copy costs, but nothing in the build can generate one from another.
-      **Still open: uploading it in the Play Console**, which cannot be automated — it is tracked as
-      a checkbox in [RELEASE.md](RELEASE.md) instead. `res/drawable/icon_small.png` (32×32) is the
-      last leftover of the old icon and is referenced nowhere.
-- [ ] Lint reports 47 unused resources and 30 missing German translations. The `res/values-v14/`
-      part of that is done: the folder held a single `widget_margin`, a left-over override from an
-      app widget that no longer exists, and lint flagged the whole `-v14` qualifier as pointless at
-      minSdk 24 anyway. Both definitions are gone with it. Its neighbour `widget_button_width`
-      (`res/values/dimension.xml`) is unreferenced too and was left alone — that belongs to the
-      unused-resource sweep, not to this.
+- [ ] Lint reports 47 unused resources and 30 missing German translations. One of the unused ones is
+      `widget_button_width` in `res/values/dimension.xml`, left over from the app widget that no
+      longer exists — its neighbour `widget_margin` and the whole `res/values-v14/` override are
+      already gone.
 - [ ] `allowBackup="true"` without `dataExtractionRules`. Not a bug — the API 31 default backs
       everything up, including receiver IPs in the SharedPreferences — but an explicit rule would be
       cleaner. Note this got wider when the log moved to `getExternalFilesDir(null)`: that directory
       is inside the default full-backup scope, the old shared-external `AVRRemote/` was not, so with
       logging enabled the log files and `avrremote.zip` — which contain the same receiver IPs, via
       `AVRSettings.getAll()` — now travel with the backup too.
-- [x] Dead version check in `StatusbarManager.updateNotification()`: a `SDK_INT >= JELLY_BEAN`
-      gate, always true at minSdk 24 (lint: `ObsoleteSdkInt`). Removed, and worth recording why it
-      was more than clutter — the `if` had no `else`, so had it ever been false the method would
-      have posted no notification at all and said nothing. The inner `>= O` check stays; API 26 is
-      above minSdk, so the notification channel really is conditional. Lint reports no
-      `ObsoleteSdkInt` at all any more — the last one was the `res/values-v14` folder qualifier,
-      which went with the item above.
-- [ ] One thing left of the two noticed in `StatusbarManager`: `createNotificationChannel` runs on
-      every call rather than once. Harmless (creating an existing channel id only updates the name;
-      importance can only be lowered and the sound is ignored after creation), but it belongs in
-      `AVRApplication.onCreate`. The other one is done — the field `private Notification
-      notification;` was never read or written, the only notification in play being the local in
-      `updateNotification()`, and it is gone. The `android.app.Notification` import stays, that
-      local still needs it.
+- [ ] `StatusbarManager.createNotificationChannel` runs on every call rather than once. Harmless
+      (creating an existing channel id only updates the name; importance can only be lowered and the
+      sound is ignored after creation), but it belongs in `AVRApplication.onCreate`.
+- [ ] **The icon artwork exists in four copies that have to move together**:
+      `res/drawable/ic_launcher_foreground.xml` (plus its API 24/25 twin in `mipmap-anydpi/`),
+      `assets/icon.svg`, `docs/avr-icon.svg` (byte-identical to the latter, feeds the GitHub Pages
+      site) and `misc/play-store-icon.svg`. Deduplicating them would be worth more than the fourth
+      copy costs, but nothing in the build can generate one from another — `magick`, `rsvg-convert`
+      and `inkscape` are all absent; the 512×512 Play Store export was rendered with macOS's
+      `qlmanage`, command recorded in a comment at the top of the SVG.
+      `res/drawable/icon_small.png` (32×32) is the last leftover of the old 2010 icon and is
+      referenced nowhere.
+- [ ] `misc/file-copyright.txt` is referenced by nothing since `misc/add-copyright.sh` was deleted.
 - [ ] **`ScreenInfo` measures the window, not the display.** The class builds its diagonal from
       `getDefaultDisplay().getMetrics()` (`ScreenInfo.java:28-33`), and every caller hands it an
       Activity — so in multi-window the numbers describe the activity's window, which is exactly why
       the API was deprecated in API 30 in favour of `WindowMetrics.getBounds()`. Nothing depends on
       the value any more: `isTablet()` and its 4.5-inch threshold are gone, and what is left only
       reaches the OSD log line and `FeedbackReporter.java:169-176`. So this is a diagnostics-quality
-      item, not a behaviour one — but a feedback report from a split-screen session currently
-      overstates nothing and understates the device, which is worth knowing before trusting one.
+      item, not a behaviour one — but a feedback report from a split-screen session understates the
+      device, which is worth knowing before trusting one.
       For the record on that threshold: it was **not** unreachable, as the commit removing the
       orientation lock claimed. Small phones above minSdk 24 exist — the Unihertz Jelly 2 is 3.0",
       the Palm PVG100 3.3" — and on those the lock fired and `ScreenListAdapter`'s 12/15/21sp ladder
       ran. Moving the size to `@dimen/osd_row_text_size` therefore does change something there:
       those devices go to 22sp in a row whose height is fixed. Rare enough to accept, not rare
       enough to have called impossible.
+- [ ] Still unexercised in `OnScreenDisplayActivity`, which was otherwise verified in August 2026 on
+      a Pixel 8 against a real receiver: the transport buttons and the search paths
+      (`btnPlay`/`btnPause`/`btnStop`, `screenMenu.doSearch()`), and the whole of `NetDisplay`'s
+      parsing beyond what that one receiver happened to send.
 
 ## Large, no deadline
 
@@ -288,7 +149,7 @@ blocks the current build, which is green.
       `startActivityForResult` → Activity Result API, 12× `new Handler()` → `Handler(Looper)`.
       All deprecated, all still compiles. Worth doing only when the look is to change — at which
       point it is unavoidable, because the pre-Holo platform themes do not allow modern styling.
-- [ ] **What is actually deprecated, by age.** 265 warnings, measured rather than guessed:
+- [ ] **What is actually deprecated, by age.** Measured rather than guessed, in August 2026:
       `./gradlew compileDebugJavaWithJavac --rerun-tasks` with `-Xlint:deprecation` **and
       `-Xmaxwarns 5000`** — javac stops at 100 by default, which silently hides the tail (that is
       how the `scan/WiFiInfo` entries went missing on the first run). Feed the warnings through
@@ -302,48 +163,22 @@ blocks the current build, which is green.
       | 15 | `PreferenceActivity.findPreference()` / `getPreferenceScreen()` / `addPreferencesFromResource()` | 7 | `AVRSettings`, `PreferenceSummaryUpdater` |
       | 15 | `Display.getWidth()` / `getHeight()` | 4 | `AVRRemote` |
       | 15 | `LayoutParams.FILL_PARENT` | 3 | `LevelActivity`, `ScreenMenu` |
-      | 15 | ~~`Build.VERSION.SDK`~~ | 1 | `log/FeedbackReporter.java:164` — done |
       | 16 | `Configuration.ORIENTATION_SQUARE` | 1 | `AVRRemote.java:357` |
       | 22 | `Resources.getDrawable()` | 8 | `AVRTheme`, `IconManager`, `OnScreenDisplayActivity` |
       | 23 | `AlertDialog.Builder.setInverseBackgroundForced()` | 6 | 4 files |
       | 29/30 | `android.preference.*` (31× `PreferenceManager`), `AsyncTask`, `TabHost`, `ListActivity`, `ExpandableListActivity`, 12× `new Handler()` | 61 | this item |
       | 31 | `WifiManager.getDhcpInfo()`, `ConnectivityManager.getAllNetworks()` | 4 | `scan/WiFiInfo` — the targetSdk 37 item |
-      | 34 | ~~`Class.newInstance()`~~ | 1 | `models/ModelConfigurator.java:85` — done |
 
       `TabActivity` is the oldest thing in the app by a wide margin — deprecated in Android 3.2, so
       **15 years**. It cannot be picked off on its own: it and the API 29/30 block are the same
       AppCompat migration, which is why the age does not translate into urgency.
-- [ ] One left of the three one-liners from that table, and it is the one that is not merely
-      mechanical: `Configuration.ORIENTATION_SQUARE` (`AVRRemote.java:357`) is **not** dead code.
-      The app computes the orientation itself from display width and height and returns that
-      constant, so the branch can still fire on a square window. It is the *constant* that is
-      obsolete — the platform has not reported it since Android 4.1 — so replacing it means
-      deciding what a square window should mean here, not just swapping a name.
-      Done: `Build.VERSION.SDK` → `SDK_INT` (it sits in the crash report users send in), and
-      `Class.newInstance()` → `getDeclaredConstructor().newInstance()` in the reflection registry.
-      The second one is worth a note for the next reader: it now throws `NoSuchMethodException` for
-      a model class without a no-arg constructor, where the old call threw `InstantiationException`.
-      Both land in the same `catch (Exception)` → `AVRGeneric`, and `ModelConfiguratorTest` drives
-      all 60 models plus the unknown-name case through it.
+- [ ] The one entry in that table that is a genuine decision rather than a rename:
+      `Configuration.ORIENTATION_SQUARE` (`AVRRemote.java:357`) is **not** dead code. The app
+      computes the orientation itself from display width and height and returns that constant, so
+      the branch can still fire on a square window. It is the *constant* that is obsolete — the
+      platform has not reported it since Android 4.1 — so replacing it means deciding what a square
+      window should mean here.
 - [ ] The custom-background picker stores the picked URI (`AVRSettings.java:92`, listener registered
       at `:62`) without `takePersistableUriPermission()`, so it does not survive a restart. Note the
       fix is not just an added call: the picker uses `ACTION_PICK`, and persistable permissions need
       `ACTION_OPEN_DOCUMENT`. Part of the same Activity-Result-API rewrite.
-- [x] `OnScreenDisplayActivity` was never exercised during the SDK 36 verification — reaching it
-      needs receiver display data. Done in August 2026 on a Pixel 8 (Android 17) against a real
-      receiver, with display lines actually populated: the list renders, the row text is the
-      expected size, and the screen rotates cleanly now that the portrait lock is gone — including
-      landscape, which falls back to the portrait layout because the OSD layouts have no
-      `layout-land` variant. Still unexercised there: the transport buttons and the search paths
-      (`btnPlay`/`btnPause`/`btnStop`, `screenMenu.doSearch()`), and the whole of `NetDisplay`'s
-      parsing beyond what that one receiver happened to send.
-
-## Answered
-
-- [x] The README links to the **Google Play Store**, but the release workflow builds an APK for
-      GitHub Releases. Answered: the App Bundle requirement applies to apps published **since
-      August 2021**; apps that were already on Play may keep shipping APKs, so the workflow does not
-      have to change. The Play upload was never automated in the first place — the `v*` tag only
-      creates a GitHub Release, and the Console step is manual. Switching to an AAB would force
-      enrolment in Play App Signing, which is irreversible, so it is worth doing only if the Console
-      actually refuses the APK. Details, deadlines and the Console checklist: [RELEASE.md](RELEASE.md).


### PR DESCRIPTION
Reine Dokumentation. `TODO.md` war auf **349 Zeilen** gewachsen, 21 der 40 Einträge erledigt. Jetzt **184 Zeilen**, 22 offene Einträge, keine Häkchen mehr.

## Keine reine Löschaktion

Was ein geschlossener Punkt festgestellt hat und ein offener noch braucht, ist in den offenen eingearbeitet:

- **Die drei Legacy-API-Stränge** (`getDhcpInfo()`, der `WifiManager`-Broadcast als Trigger, `getAllNetworks()`) sind ein Punkt mit drei Unterpunkten geworden — inklusive der Eigenschaft, die jeder `NetworkCallback`-Umbau erhalten muss: erst das aktive Netz, dann alle. Ein WLAN ohne Internet ist nicht das Default-Netz, und `AVRScanner.java:117` verweigert bei `false` den ganzen Scan. Genau dieser Zusammenhang wäre sonst mit dem erledigten Crash-Eintrag verschwunden.
- **Der nicht reproduzierbare Absturz** ist ein vorwärtsgerichteter Punkt geworden: auf eine zweite NPE in `AVRApplication$1.onReceive` achten — die würde die Beta-These widerlegen.
- Der Series08-Leerseiten-Guard ist in „kein Receiver zum Testen" gewandert, der DOCTYPE-Nebeneffekt in den Parser-Punkt, den er betrifft, und die Stale-Teardown-Race in den Service-Punkt, der sie referenzierte.
- **Zwei Dinge waren in erledigten Einträgen vergraben und sind offen:** die vier Kopien der Icon-Grafik, die zusammen bewegt werden müssen, und was in `OnScreenDisplayActivity` weiterhin ungetestet ist (Transport-Buttons, Suchpfade, `NetDisplay`-Parsing).

## Querverweise, die sonst ins Leere gelaufen wären

| Datei | Was falsch geworden wäre |
|---|---|
| `CLAUDE.md` | verwies auf die try-with-resources-Inventur in `TODO.md` — weg und erledigt; nennt jetzt nur noch `Connector.java:168` als den einen Block, der bleibt |
| `CLAUDE.md` | Abschnitt „Known-broken" beschrieb einen `TODO.md`-Abschnitt, den es nicht mehr gibt |
| `CONNECTION.md` | behauptete, `Zone4` fehle in der Reset-Kaskade — seit #32 nicht mehr; umformuliert als Historie, die beim Lesen älterer Logs hilft |
| `RELEASE.md` | Schritt 3 sagte „Tick the items" |

## Konvention

`CLAUDE.md` sagt jetzt: erledigte Punkte **löschen** statt abhaken, im selben Commit — die Datei bleibt nur lesbar, wenn sich Erledigtes nicht ansammelt, und „was wurde gemacht und warum" steht in der Historie. Trägt ein geschlossener Punkt etwas, worauf ein offener sich stützt, gehört es in den offenen.

`./gradlew build` grün (an den Quellen ändert der PR nichts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJYiak7auvjb2n6eZMJvzf