### PR TITLE
Tests for the Series08 parsers, the NSE display reader and the tuner frequency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,13 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
-**There is almost no test coverage.** `src/test` holds six JVM test classes on JUnit 4, the only
+**There is almost no test coverage.** `src/test` holds eight JVM test classes on JUnit 4, the only
 dependency in the project — `http/HTTPSupportTest`, `http/Series08ParserTest`,
-`core/ThreadHandlerTest`, `models/ModelConfiguratorTest`, `ReceiverStatusTest` and
+`core/ThreadHandlerTest`, `core/InDataTest`, `core/display/NetDisplayTest`,
+`models/ModelConfiguratorTest`, `ReceiverStatusTest` and
 `http/AVRXMLInfoParserTest` — and there is no `src/androidTest` at all. `./gradlew test` runs a few
 dozen cases and nothing else (twice, in fact: once per build variant), so do not report a change as
-verified because the build passed; verify on a device or emulator instead. Five limits are worth
+verified because the build passed; verify on a device or emulator instead. Six limits are worth
 knowing before writing more tests:
 
 - These run on the desktop JVM, not on Android's OkHttp-backed stack. Anything Android-specific —
@@ -71,6 +72,17 @@ knowing before writing more tests:
   `inputs.file` entry nor the module/root path dance above. Keep such captures byte-exact — one of
   the two has CRLF line endings and both pad their values with spaces, and the tests exist to pin
   what the parsers do with that.
+- **A static initialiser that touches `android.os.Build` locks the whole class out of JVM tests.**
+  The stub `android.jar` leaves those fields null, so the initialiser throws and every test using
+  the class dies with `ExceptionInInitializerError` — including classes that merely *use* it, which
+  makes the cause hard to see. `core/InData` had exactly that: an `EXTENDED_DEBUG` field calling
+  `EmulationDetector.isEmulator()`, for a debug string. It is now read inside `toDebugString()`
+  instead, which is what makes `core/InDataTest` and `core/display/NetDisplayTest` possible at all —
+  `NetDisplay.DisplayStatusReader` takes an `InData`. Constructors and field initialisers of Android
+  types are fine (`NetDisplay` builds a `Handler` in a field initialiser and still constructs on a
+  JVM); it is *reading* `Build` that fails. So the display classes need no keep-alive trick: the
+  test builds `new NetDisplay(null, null, DisplayType.NETWORK)` and reaches the inner
+  `DisplayStatusReader` directly, because for `NETWORK` the constructor touches neither argument.
 - `core/ThreadHandlerTest` asserts on wall-clock time, as does `Series08ParserTest`'s
   `largeLineStaysFast`. Its threshold sits between "no wait" and the `join(1000)` it replaced
   (measured 1003 ms), so keep that margin if you touch it. It reaches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,17 +72,24 @@ knowing before writing more tests:
   `inputs.file` entry nor the module/root path dance above. Keep such captures byte-exact — one of
   the two has CRLF line endings and both pad their values with spaces, and the tests exist to pin
   what the parsers do with that.
-- **A static initialiser that touches `android.os.Build` locks the whole class out of JVM tests.**
-  The stub `android.jar` leaves those fields null, so the initialiser throws and every test using
-  the class dies with `ExceptionInInitializerError` — including classes that merely *use* it, which
-  makes the cause hard to see. `core/InData` had exactly that: an `EXTENDED_DEBUG` field calling
-  `EmulationDetector.isEmulator()`, for a debug string. It is now read inside `toDebugString()`
-  instead, which is what makes `core/InDataTest` and `core/display/NetDisplayTest` possible at all —
-  `NetDisplay.DisplayStatusReader` takes an `InData`. Constructors and field initialisers of Android
-  types are fine (`NetDisplay` builds a `Handler` in a field initialiser and still constructs on a
-  JVM); it is *reading* `Build` that fails. So the display classes need no keep-alive trick: the
-  test builds `new NetDisplay(null, null, DisplayType.NETWORK)` and reaches the inner
-  `DisplayStatusReader` directly, because for `NETWORK` the constructor touches neither argument.
+- **A static initialiser that touches Android locks the whole class out of JVM tests.** Three
+  different behaviours in the stub `android.jar`, and only the third one throws by itself:
+  constructors are no-ops (`new Handler()` works), **field reads return null or 0**
+  (`Build.PRODUCT` is null), and **method calls throw** `RuntimeException: Method … not mocked`
+  (`SystemClock.uptimeMillis()`, `TextUtils.isEmpty`). `testOptions.unitTests.returnDefaultValues`
+  is not set here, and turning it on would only paper over the third case.
+  So a class dies at load time either when a static initialiser calls an Android method, or when it
+  uses a null that a field read handed back. `core/InData` had the second kind: an `EXTENDED_DEBUG`
+  field calling `EmulationDetector.isEmulator()`, which does `Build.PRODUCT.toUpperCase()` — an NPE
+  inside `<clinit>`. Every test touching `InData` then died with `ExceptionInInitializerError`,
+  including tests of classes that merely *use* it, which makes the cause hard to see (restoring the
+  field kills 20 of the 50 tests). It is now read inside `toDebugString()`, where it is used, and
+  that is what makes `core/InDataTest` and `core/display/NetDisplayTest` possible at all —
+  `NetDisplay.DisplayStatusReader` takes an `InData`. The display classes need no keep-alive trick
+  beyond that: the test builds `new NetDisplay(null, null, DisplayType.NETWORK)` — a `Handler` in a
+  field initialiser is harmless — and reaches the inner `DisplayStatusReader` directly, because for
+  `NETWORK` the constructor touches neither argument. `TunerDisplayTest` reaches `TunerFrequency`
+  the same way.
 - `core/ThreadHandlerTest` asserts on wall-clock time, as does `Series08ParserTest`'s
   `largeLineStaysFast`. Its threshold sits between "no wait" and the `join(1000)` it replaced
   (measured 1003 ms), so keep that margin if you touch it. It reaches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,10 @@ $ANDROID_HOME/platform-tools/adb install -r app/build/outputs/apk/debug/app-debu
 
 `local.properties` is deliberately untracked — the SDK path comes from `ANDROID_HOME`.
 
-**There is almost no test coverage.** `src/test` holds eight JVM test classes on JUnit 4, the only
+**There is almost no test coverage.** `src/test` holds nine JVM test classes on JUnit 4, the only
 dependency in the project — `http/HTTPSupportTest`, `http/Series08ParserTest`,
 `core/ThreadHandlerTest`, `core/InDataTest`, `core/display/NetDisplayTest`,
-`models/ModelConfiguratorTest`, `ReceiverStatusTest` and
+`core/display/TunerDisplayTest`, `models/ModelConfiguratorTest`, `ReceiverStatusTest` and
 `http/AVRXMLInfoParserTest` — and there is no `src/androidTest` at all. `./gradlew test` runs a few
 dozen cases and nothing else (twice, in fact: once per build variant), so do not report a change as
 verified because the build passed; verify on a device or emulator instead. Six limits are worth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ dependency in the project — `http/HTTPSupportTest`, `http/Series08ParserTest`,
 `core/ThreadHandlerTest`, `models/ModelConfiguratorTest`, `ReceiverStatusTest` and
 `http/AVRXMLInfoParserTest` — and there is no `src/androidTest` at all. `./gradlew test` runs a few
 dozen cases and nothing else (twice, in fact: once per build variant), so do not report a change as
-verified because the build passed; verify on a device or emulator instead. Four limits are worth
+verified because the build passed; verify on a device or emulator instead. Five limits are worth
 knowing before writing more tests:
 
 - These run on the desktop JVM, not on Android's OkHttp-backed stack. Anything Android-specific —
@@ -64,6 +64,13 @@ knowing before writing more tests:
   (it covers both variants — verified by watching `testReleaseUnitTest` re-run too). It also
   resolves its paths against both the module and the root directory, because the working directory
   depends on how the run was started.
+- Real device output belongs in `src/test/resources`, not next to the source or read from disk.
+  `Series08ParserTest` parses two captured AVR-3808 pages from
+  `src/test/resources/de/pskiwi/avrremote/http/` through `getResourceAsStream`; Gradle puts that
+  directory on the test classpath and tracks it as a task input by itself, so it needs neither an
+  `inputs.file` entry nor the module/root path dance above. Keep such captures byte-exact — one of
+  the two has CRLF line endings and both pad their values with spaces, and the tests exist to pin
+  what the parsers do with that.
 - `core/ThreadHandlerTest` asserts on wall-clock time, as does `Series08ParserTest`'s
   `largeLineStaysFast`. Its threshold sits between "no wait" and the `join(1000)` it replaced
   (measured 1003 ms), so keep that margin if you touch it. It reaches

--- a/TODO.md
+++ b/TODO.md
@@ -43,11 +43,16 @@ one still depends on has been folded into the live one.
 - [ ] **Test coverage is nine JVM classes and no instrumentation tests.** The cheapest places to add
       more are `models/` (pure capability logic, no Android types) and `core/ZoneState.java`
       (1237 lines). `core/display/` is now part done: `NetDisplayTest` covers the line reader and
-      `TunerDisplayTest` the frequency conversion, but the rest of `TunerDisplay` (1059 lines —
-      presets, HD Radio, DAB, the status lines) and all of `BDDisplay` have nothing. Both *do*
-      construct on a JVM — `TunerDisplay.createFM(null, null)` and `new BDDisplay(null)` work, and
-      their public inner classes can be instantiated from a test the same way `TunerDisplayTest`
-      reaches `TunerFrequency` — so the obstacle is only that nobody has written the cases.
+      `TunerDisplayTest` the frequency conversion, but the rest of `TunerDisplay` (presets, HD Radio,
+      DAB, the status lines) and all of `BDDisplay` have nothing. Both construct on a JVM
+      (`TunerDisplay.createFM(null, null)`, `new BDDisplay(null)`), but only `TunerDisplay` can be
+      driven from a test as it stands: its `TunerFrequency` is a public inner class, so
+      `outer.new TunerFrequency()` works. **`BDDisplay` cannot** — `BDDisplayStatus` is
+      `private final static` (`BDDisplay.java:38`) and `BDState` is `private final`
+      (`BDDisplay.java:192`), and `getState()` hands back only the `IAVRState` interface. Testing it
+      needs the same widening as `ResilentConnector.ThreadHandler` and
+      `ModelConfigurator.createModel(String)`: make the nested class package-private, and say in a
+      comment that the test is why.
 - [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and
       `endElement` read `localName`, which a standard `SAXParserFactory` leaves empty because it is
       not namespace-aware by default — on a JVM the parser silently collects nothing. Android's

--- a/TODO.md
+++ b/TODO.md
@@ -40,9 +40,15 @@ one still depends on has been folded into the live one.
 
 ## Structural
 
-- [ ] **Test coverage is six JVM classes and no instrumentation tests.** The cheapest places to add
+- [ ] **Test coverage is eight JVM classes and no instrumentation tests.** The cheapest places to add
       more are `models/` (pure capability logic, no Android types) and `core/ZoneState.java`
-      (1237 lines).
+      (1237 lines). `core/display/` is now half done: `NetDisplayTest` covers the line reader, but
+      `TunerDisplay` (1059 lines) and `BDDisplay` have nothing. Both *do* construct on a JVM —
+      `TunerDisplay.createFM(null, null)` and `new BDDisplay(null)` were tried and work — so the
+      obstacle is only that nobody has written the cases. `TunerDisplay.TunerFrequency` is the
+      obvious start: `convertFrequency` splits FM from AM at 50000, which the 2007 protocol paper
+      words as "(>050000 is AM.)" — note it puts exactly 050000 on the AM side where the paper reads
+      as FM, an edge the tuner never actually sits on.
 - [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and
       `endElement` read `localName`, which a standard `SAXParserFactory` leaves empty because it is
       not namespace-aware by default — on a JVM the parser silently collects nothing. Android's

--- a/TODO.md
+++ b/TODO.md
@@ -40,15 +40,14 @@ one still depends on has been folded into the live one.
 
 ## Structural
 
-- [ ] **Test coverage is eight JVM classes and no instrumentation tests.** The cheapest places to add
+- [ ] **Test coverage is nine JVM classes and no instrumentation tests.** The cheapest places to add
       more are `models/` (pure capability logic, no Android types) and `core/ZoneState.java`
-      (1237 lines). `core/display/` is now half done: `NetDisplayTest` covers the line reader, but
-      `TunerDisplay` (1059 lines) and `BDDisplay` have nothing. Both *do* construct on a JVM —
-      `TunerDisplay.createFM(null, null)` and `new BDDisplay(null)` were tried and work — so the
-      obstacle is only that nobody has written the cases. `TunerDisplay.TunerFrequency` is the
-      obvious start: `convertFrequency` splits FM from AM at 50000, which the 2007 protocol paper
-      words as "(>050000 is AM.)" — note it puts exactly 050000 on the AM side where the paper reads
-      as FM, an edge the tuner never actually sits on.
+      (1237 lines). `core/display/` is now part done: `NetDisplayTest` covers the line reader and
+      `TunerDisplayTest` the frequency conversion, but the rest of `TunerDisplay` (1059 lines —
+      presets, HD Radio, DAB, the status lines) and all of `BDDisplay` have nothing. Both *do*
+      construct on a JVM — `TunerDisplay.createFM(null, null)` and `new BDDisplay(null)` work, and
+      their public inner classes can be instantiated from a test the same way `TunerDisplayTest`
+      reaches `TunerFrequency` — so the obstacle is only that nobody has written the cases.
 - [ ] **`http/AVRXMLInfoParser` only works on Android and cannot be unit-tested.** `startElement` and
       `endElement` read `localName`, which a standard `SAXParserFactory` leaves empty because it is
       not namespace-aware by default — on a JVM the parser silently collects nothing. Android's

--- a/TODO.md
+++ b/TODO.md
@@ -54,17 +54,16 @@ one still depends on has been folded into the live one.
       JVM it now rejects **any** XML carrying a DOCTYPE, because `disallow-doctype-decl` applies
       there and on Android it does not (see CLAUDE.md). Receivers never send one, so nothing breaks
       in the app.
-- [ ] **Nothing in the 2008-series path was verified against hardware.** The Apache removal touched
-      all of it and none of it could be exercised — no such receiver was available. Affected:
-      `http/Series08Reader` (the cookie store it clears per run, and the `r_option1.asp` →
-      `d_option1.asp` sequence that depends on shared session state), plus
-      `http/Series08ZoneRenameParser` and `http/Series08QuickSelectParser`, whose `OPTION_PATTERN`
-      went from `matches()` with a wrapping `.*` to `find()` in a loop. `http/Series08ParserTest`
-      pins the behaviour that could have broken — notably that the **last** match in a line wins,
-      not the first, which is what the old greedy `.*` did — but those tests were written from the
-      code, not from a real page. The empty-page guard in `Series08InputParser` is unverified for
-      the same reason. One run against a 2008-series receiver settles all of it: check that input
-      names, zone names and quick-select names all still appear.
+- [ ] **The 2008-series path is only half covered by real data.** Two pages of an AVR-3808 are now
+      captured under `app/src/test/resources/de/pskiwi/avrremote/http/`, and `Series08ParserTest`
+      parses them verbatim — that settles `Series08InputParser` (including its empty-page guard) and
+      `Series08ZoneRenameParser`. What is left has no capture and no test:
+      `http/Series08QuickSelectParser`, whose `d_option1.asp` was never recorded and which is still
+      pinned only by cases derived from the code, and `http/Series08Reader` — the cookie store it
+      clears per run, and the `r_option1.asp` → `d_option1.asp` sequence that depends on shared
+      session state, neither reachable without HTTP. One run against a 2008-series receiver settles
+      both: check that quick-select names appear at all. A capture of `d_option1.asp` would settle
+      the parser half on its own.
 - [ ] Same area, cookie lifetime: the store is cleared per Series08 read
       (`Series08Reader.readSeries08Info`), whereas the old `DefaultHttpClient` was per
       `AVRHTTPClient` instance, so it also covered the multi-zone path. Exact parity would clear it

--- a/app/src/main/java/de/pskiwi/avrremote/core/InData.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/InData.java
@@ -90,8 +90,11 @@ public final class InData {
 			final byte[] raw = new byte[data.length - start];
 			int count = 0;
 			for (int i = start; i < data.length; i++) {
-				raw[i - start] = (byte) (data[i] > 127 ? data[i] - 256
-						: data[i]);
+				// Der Receiver schickt Bytes, die hier je in einem char
+				// stehen. Die Verengung auf byte nimmt die unteren acht Bit -
+				// genau das, was ein früheres "data[i] > 127 ? data[i] - 256"
+				// von Hand tat, denn -256 lässt eben diese Bits unberührt.
+				raw[i - start] = (byte) data[i];
 				if (data[i] != 0) {
 					count++;
 				} else {

--- a/app/src/main/java/de/pskiwi/avrremote/core/InData.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/InData.java
@@ -118,7 +118,13 @@ public final class InData {
 	}
 
 	public String toDebugString() {
-		final int max = EXTENDED_DEBUG ? count : (count > MAX_DEBUG ? MAX_DEBUG
+		// Erst hier abgefragt, nicht in einem Klassenfeld: EmulationDetector
+		// liest android.os.Build, und das ist auf einer nackten JVM null. Als
+		// static-Initialisierer hätte InData sich damit aus jedem Unit-Test
+		// ausgesperrt, für eine reine Debug-Ausgabe. EmulationDetector rechnet
+		// selbst nur einmal, das hier ist ein Feldzugriff.
+		final boolean extendedDebug = EmulationDetector.isEmulator();
+		final int max = extendedDebug ? count : (count > MAX_DEBUG ? MAX_DEBUG
 				: count);
 		return toBaseDebug() + toHexDebug(max);
 	}
@@ -148,7 +154,6 @@ public final class InData {
 	private int offset;
 	private final char[] data;
 	private final int count;
-	private static boolean EXTENDED_DEBUG = EmulationDetector.isEmulator();
 	private final static int MAX_DEBUG = 15;
 
 }

--- a/app/src/main/java/de/pskiwi/avrremote/core/display/TunerDisplay.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/display/TunerDisplay.java
@@ -163,11 +163,12 @@ public final class TunerDisplay implements IDisplay {
 				return "" + frequency;
 			}
 			if (freq > 0) {
-				// DENON AVR control protocol Ver. 5.2, TF AN******:
-				// "(>050000 is AM.)" - erst oberhalb von 050000 ist es AM,
-				// 050000 selbst gehört noch zu FM. Praktisch liegt dazwischen
-				// nichts: UKW endet bei 10800, MW beginnt bei 52200.
-				final boolean fm = (freq <= 50000);
+				// DENON AVR control protocol Ver. 5.2, TF AN******: beide
+				// Grenzen sind strikt notiert, "(>050000 is AM.)" und
+				// "(<050000 is FM.)". Der Grenzwert selbst bleibt damit
+				// unbestimmt; hier fällt er auf die AM-Seite. Praktisch liegt
+				// dort nichts: UKW endet bei 10800, MW beginnt bei 52200.
+				final boolean fm = (freq < 50000);
 				return (fm ? "FM" : "AM") + " : "
 						+ String.format("%2.2f ", freq / 100f)
 						+ (fm ? "MHz" : "kHz");

--- a/app/src/main/java/de/pskiwi/avrremote/core/display/TunerDisplay.java
+++ b/app/src/main/java/de/pskiwi/avrremote/core/display/TunerDisplay.java
@@ -163,7 +163,11 @@ public final class TunerDisplay implements IDisplay {
 				return "" + frequency;
 			}
 			if (freq > 0) {
-				final boolean fm = (freq < 50000);
+				// DENON AVR control protocol Ver. 5.2, TF AN******:
+				// "(>050000 is AM.)" - erst oberhalb von 050000 ist es AM,
+				// 050000 selbst gehört noch zu FM. Praktisch liegt dazwischen
+				// nichts: UKW endet bei 10800, MW beginnt bei 52200.
+				final boolean fm = (freq <= 50000);
 				return (fm ? "FM" : "AM") + " : "
 						+ String.format("%2.2f ", freq / 100f)
 						+ (fm ? "MHz" : "kHz");

--- a/app/src/main/java/de/pskiwi/avrremote/http/Series08ZoneRenameParser.java
+++ b/app/src/main/java/de/pskiwi/avrremote/http/Series08ZoneRenameParser.java
@@ -78,7 +78,7 @@ public final class Series08ZoneRenameParser {
 	}
 
 	public String getZoneName(int zone) {
-		if (zone < 0 || zone > ZONE_KEYS.length) {
+		if (zone < 0 || zone >= ZONE_KEYS.length) {
 			throw new IllegalArgumentException("zone:" + zone);
 		}
 		return map.get(ZONE_KEYS[zone]);

--- a/app/src/test/java/de/pskiwi/avrremote/core/InDataTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/core/InDataTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.core;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * InData zerlegt eine Zeile des Anzeige-Protokolls. Die Regeln stehen im
+ * DENON AVR control protocol Ver. 5.2 (AVR-3808CI, Juli 2007) beim Ereignis
+ * NSA, dort als Muster notiert:
+ *
+ * <pre>
+ * NSA0**************_?????&lt;CR&gt;
+ *   *:Character Length MAX96
+ *   _:Null
+ *   ?:Exclusion(The character after Null should be disregarded)
+ * </pre>
+ *
+ * Die Ziffer hinter dem Kommando ist die Zeilennummer, danach folgt der Text,
+ * und ein Nullbyte beendet ihn - alles dahinter ist zu verwerfen. Genau das
+ * bilden getDisplayLineNumber() und extractLine() ab.
+ *
+ * Zur Einordnung: das Papier beschreibt NSA/IPA, die App spricht mit NSE/IPE
+ * eine spätere Generation derselben Kommandos. Der Rahmen - Ziffer, Flag-Byte,
+ * nullterminierter Text - ist in beiden derselbe, die Bedeutung der einzelnen
+ * Zeilennummern nicht (siehe NetDisplayTest).
+ */
+public final class InDataTest {
+
+	@Test
+	public void displayLineNumberIsTheLeadingDigit() {
+		assertEquals(0, new InData("0Internet Radio").getDisplayLineNumber());
+		assertEquals(8, new InData("8 [   4/  17]").getDisplayLineNumber());
+	}
+
+	/** "_:Null / ?:The character after Null should be disregarded". */
+	@Test
+	public void extractLineStopsAtTheNullByte() {
+		final InData d = new InData("1 Jazz Radio\0RESTMUELL");
+
+		assertEquals("Jazz Radio", d.extractLine(2));
+	}
+
+	/** Ohne Nullbyte reicht der Text bis zum Ende der Daten. */
+	@Test
+	public void extractLineWithoutNullTakesEverything() {
+		assertEquals("Jazz Radio", new InData("1 Jazz Radio").extractLine(2));
+	}
+
+	/**
+	 * Die Bytes des Receivers stehen einzeln in je einem char. extractLine
+	 * schiebt sie zurück in ein byte[] und liest das als UTF-8 - hier C3 A9 für
+	 * "é". Ohne den Rückschub käme "Ã©" heraus.
+	 */
+	@Test
+	public void extractLineDecodesUtf8() {
+		final InData d = new InData("1 Caf\u00c3\u00a9");
+
+		assertEquals("Caf\u00e9", d.extractLine(2));
+	}
+
+	/**
+	 * Der Versatz überspringt das Kommando, so wie es AVRState und ZoneState
+	 * vor der Weitergabe tun. Danach zählen charAt() und extractLine() ab dem
+	 * ersten Zeichen dahinter.
+	 */
+	@Test
+	public void offsetSkipsTheCommand() {
+		final InData d = new InData("NSE1 Jazz Radio");
+		d.setOffset("NSE".length());
+
+		assertEquals(1, d.getDisplayLineNumber());
+		assertEquals(' ', d.charAt(1));
+		assertEquals("Jazz Radio", d.extractLine(2));
+	}
+}

--- a/app/src/test/java/de/pskiwi/avrremote/core/InDataTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/core/InDataTest.java
@@ -40,6 +40,13 @@ import org.junit.Test;
  * eine spätere Generation derselben Kommandos. Der Rahmen - Ziffer, Flag-Byte,
  * nullterminierter Text - ist in beiden derselbe, die Bedeutung der einzelnen
  * Zeilennummern nicht (siehe NetDisplayTest).
+ *
+ * Alle Fälle hier benutzen den String-Konstruktor, bei dem data.length und
+ * count übereinstimmen. Im Betrieb kommt der andere zum Zug: Connector reicht
+ * seinen festen Puffer samt getrennter Länge herein. extractLine läuft bis
+ * data.length und nicht bis count, geht also über das Ende der Nutzlast
+ * hinaus - dass dabei nichts Fremdes anfällt, hängt daran, dass der Puffer je
+ * Lesevorgang mit Nullen anfängt. Das ist hier nicht abgedeckt.
  */
 public final class InDataTest {
 

--- a/app/src/test/java/de/pskiwi/avrremote/core/display/NetDisplayTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/core/display/NetDisplayTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.core.display;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import de.pskiwi.avrremote.core.InData;
+import de.pskiwi.avrremote.core.display.DisplayManager.DisplayType;
+
+/**
+ * NetDisplay.DisplayStatusReader setzt die neun Zeilen einer Bildschirmseite
+ * zusammen. Das Format steht im DENON AVR control protocol Ver. 5.2
+ * (AVR-3808CI, Juli 2007):
+ *
+ * <pre>
+ * NSA0**************_?????   Display Line1   - ohne Flag-Byte
+ * NSA1※************_?????    Display Line3   - mit Flag-Byte
+ * ...
+ *   ※:Cursor&amp;Playable Music Infomation Data(1Byte)
+ *     Bit1:Playable Music =1
+ *     Bit2,3:Don't Care
+ *     Bit4:CURSOR SELECT=1
+ *     Bit5,6,7,8:Don't Care
+ * </pre>
+ *
+ * Bit1 ist der Wert 1, Bit4 der Wert 8 - genau die Masken, die update()
+ * abfragt. Bit2 (Verzeichnis) und Bit8 (Bild) wertet die App zusätzlich aus;
+ * für den 3808 sind sie laut Papier "Don't Care", spätere Geräte belegen sie.
+ *
+ * Das Papier beschreibt NSA/IPA, die App spricht NSE/IPE - eine spätere
+ * Generation derselben Kommandos, gleicher Rahmen. Wo beide auseinandergehen,
+ * gilt hier der Code, und es steht am Testfall dabei: das Papier setzt das
+ * Flag-Byte nur auf die Zeilen 1 bis 6, die App liest es auf 1 bis 7.
+ *
+ * Alle Fälle laufen gegen den Netzwerk-Bildschirm mit seinen acht Zeilen
+ * (displayRows=8), also NSE0 bis NSE8.
+ */
+public final class NetDisplayTest {
+
+	/** Bit1 - "Playable Music". */
+	private final static int PLAYABLE = 1;
+	/** Bit2 - Verzeichnis; im 3808-Papier "Don't Care". */
+	private final static int DIRECTORY = 2;
+	/** Bit4 - "CURSOR SELECT". */
+	private final static int CURSOR = 8;
+	/** Bit8 - Bild; im 3808-Papier "Don't Care". */
+	private final static int PICTURE = 128;
+	/** Keines der ausgewerteten Bits gesetzt. */
+	private final static int NONE = ' ';
+
+	@Test
+	public void flagByteMarksPlayableDirectoryAndCursor() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, PLAYABLE, "Ein Titel"), line(2, DIRECTORY, "Ein Ordner"),
+				line(3, PLAYABLE | CURSOR, "Unter dem Cursor"),
+				line(4, PICTURE, "Mit Bild"), line(5, NONE, ""),
+				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
+
+		assertTrue(s.getDisplayLine(0).isPlayable());
+		assertFalse(s.getDisplayLine(0).isFolder());
+
+		assertTrue(s.getDisplayLine(1).isFolder());
+		assertFalse(s.getDisplayLine(1).isPlayable());
+
+		assertTrue(s.getDisplayLine(2).isPlayable());
+		assertTrue(s.getDisplayLine(2).isCursor());
+
+		assertFalse(s.getDisplayLine(3).isPlayable());
+	}
+
+	/**
+	 * Das Cursor-Bit setzt zugleich die Cursorzeile, und zwar um eins versetzt:
+	 * NSE1 ist der erste Eintrag der Liste, weil NSE0 der Titel ist.
+	 */
+	@Test
+	public void cursorBitSetsTheCursorLine() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Eins"), line(2, NONE, "Zwei"),
+				line(3, CURSOR, "Drei"), line(4, NONE, ""), line(5, NONE, ""),
+				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
+
+		assertTrue(s.isCursorDefined());
+		assertEquals(2, s.getCursorLine());
+		assertEquals("Drei", s.getDisplayLine(s.getCursorLine()).getLine());
+	}
+
+	/** Ohne gesetztes Bit gibt es keine Cursorzeile. */
+	@Test
+	public void withoutCursorBitThereIsNoCursorLine() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Eins"), line(2, NONE, "Zwei"),
+				line(3, NONE, "Drei"), line(4, NONE, ""), line(5, NONE, ""),
+				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
+
+		assertFalse(s.isCursorDefined());
+		assertEquals(-1, s.getCursorLine());
+	}
+
+	/**
+	 * Erste und letzte Zeile tragen kein Flag-Byte, haben aber trotzdem
+	 * verschiedene Textanfänge: NSE0 ab Index 1, NSE8 ab Index 2. Würde für die
+	 * erste Zeile ebenfalls 2 gelten, fehlte dem Titel sein erstes Zeichen.
+	 */
+	@Test
+	public void firstAndLastLineCarryNoFlagByte() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Eins"), line(2, NONE, ""), line(3, NONE, ""),
+				line(4, NONE, ""), line(5, NONE, ""), line(6, NONE, ""),
+				line(7, NONE, ""), "8 [   4/  17]");
+
+		assertEquals("Internet Radio", s.getTitle());
+		assertEquals("[   4/  17]", s.getInfoLine());
+	}
+
+	/**
+	 * Die letzte Zeile trägt die Blätterinformation "[ n/ m]". Daraus wird die
+	 * Nummer der ersten angezeigten Zeile, eins abgezogen - der Receiver zählt
+	 * ab 1, die App ab 0.
+	 */
+	@Test
+	public void lastLineCarriesThePageOffset() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Eins"), line(2, NONE, ""), line(3, NONE, ""),
+				line(4, NONE, ""), line(5, NONE, ""), line(6, NONE, ""),
+				line(7, NONE, ""), "8 [   4/  17]");
+
+		assertEquals(3, s.getOffsetLine());
+	}
+
+	/** Ohne erkennbare Blätterinformation bleibt es beim Anfang der Liste. */
+	@Test
+	public void withoutPageInfoTheOffsetStaysAtZero() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Eins"), line(2, NONE, ""), line(3, NONE, ""),
+				line(4, NONE, ""), line(5, NONE, ""), line(6, NONE, ""),
+				line(7, NONE, ""), "8 Nichts Verwertbares");
+
+		assertEquals(0, s.getOffsetLine());
+	}
+
+	/** "Manche receiver füllen mit Leerzeichen auf" - rechts wird gekürzt. */
+	@Test
+	public void trailingPaddingIsTrimmed() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Jazz Radio        "), line(2, NONE, ""),
+				line(3, NONE, ""), line(4, NONE, ""), line(5, NONE, ""),
+				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
+
+		assertEquals("Jazz Radio", s.getDisplayLine(0).getLine());
+	}
+
+	/**
+	 * Die Null-Regel des Papiers gilt auch hier: alles hinter dem Nullbyte ist
+	 * zu verwerfen, nicht anzuzeigen.
+	 */
+	@Test
+	public void textEndsAtTheNullByte() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Jazz Radio\0RESTMUELL"), line(2, NONE, ""),
+				line(3, NONE, ""), line(4, NONE, ""), line(5, NONE, ""),
+				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
+
+		assertEquals("Jazz Radio", s.getDisplayLine(0).getLine());
+	}
+
+	/**
+	 * Zwischen Titel und Infozeile bleiben die sieben Listenzeilen NSE1 bis
+	 * NSE7 stehen.
+	 */
+	@Test
+	public void titleAndInfoLineAreNotPartOfTheList() {
+		final NetDisplay.DisplayStatus s = read("0Internet Radio",
+				line(1, NONE, "Eins"), line(2, NONE, "Zwei"),
+				line(3, NONE, "Drei"), line(4, NONE, ""), line(5, NONE, ""),
+				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
+
+		assertEquals(7, s.getDisplayCount());
+		assertEquals("[Eins, Zwei, Drei, , , , ]", s.getDisplayLines()
+				.toString());
+	}
+
+	/**
+	 * Nur die letzte Zeile meldet sich als solche - daran erkennt der Aufrufer,
+	 * dass die Seite vollständig ist.
+	 */
+	@Test
+	public void onlyTheLastLineReportsCompletion() {
+		final NetDisplay.DisplayStatusReader r = reader();
+		for (int nr = 0; nr < 8; nr++) {
+			assertFalse("Zeile " + nr + " meldete sich als letzte",
+					r.update(new InData(line(nr, NONE, "x"))));
+		}
+		assertTrue(r.update(new InData("8 [   4/  17]")));
+	}
+
+	/** Nach createStatus() ist der Zustand fest und darf nicht weiterlaufen. */
+	@Test
+	public void readerRefusesUpdatesAfterCreateStatus() {
+		final NetDisplay.DisplayStatusReader r = reader();
+		r.update(new InData("0Internet Radio"));
+		r.createStatus();
+
+		try {
+			r.update(new InData(line(1, NONE, "Zu spaet")));
+			fail("Aenderung nach createStatus() nicht abgewiesen");
+		} catch (IllegalStateException expected) {
+			// so soll es sein
+		}
+	}
+
+	/**
+	 * Eine NSE-Zeile aus der Mitte: Zeilenziffer, Flag-Byte, Text. Zeile 0 und
+	 * Zeile 8 haben kein Flag-Byte und werden in den Tests ausgeschrieben.
+	 */
+	private static String line(int nr, int flags, String text) {
+		return "" + nr + (char) flags + text;
+	}
+
+	/**
+	 * NetDisplay selbst braucht Sender und ModelConfigurator erst beim
+	 * Bedienen, nicht beim Bauen - für den Netzwerk-Bildschirm setzt der
+	 * Konstruktor nur Zeilenzahl und Präfix.
+	 */
+	private static NetDisplay.DisplayStatusReader reader() {
+		return new NetDisplay(null, null, DisplayType.NETWORK).new DisplayStatusReader();
+	}
+
+	/** Füttert eine ganze Seite und liefert den fertigen Zustand. */
+	private static NetDisplay.DisplayStatus read(String... lines) {
+		final NetDisplay.DisplayStatusReader r = reader();
+		for (String l : lines) {
+			r.update(new InData(l));
+		}
+		return r.createStatus();
+	}
+}

--- a/app/src/test/java/de/pskiwi/avrremote/core/display/NetDisplayTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/core/display/NetDisplayTest.java
@@ -43,16 +43,19 @@ import de.pskiwi.avrremote.core.display.DisplayManager.DisplayType;
  * </pre>
  *
  * Bit1 ist der Wert 1, Bit4 der Wert 8 - genau die Masken, die update()
- * abfragt. Bit2 (Verzeichnis) und Bit8 (Bild) wertet die App zusätzlich aus;
- * für den 3808 sind sie laut Papier "Don't Care", spätere Geräte belegen sie.
+ * abfragt. Bit2 liest die App zusätzlich als Verzeichnis; für den 3808 ist es
+ * laut Papier "Don't Care", spätere Geräte belegen es. Bit8 landet ebenfalls
+ * in LineState, als isPicture(), wird aber von niemandem gelesen - deshalb
+ * steht dafür hier auch kein Fall, er wäre nicht prüfbar.
  *
  * Das Papier beschreibt NSA/IPA, die App spricht NSE/IPE - eine spätere
  * Generation derselben Kommandos, gleicher Rahmen. Wo beide auseinandergehen,
  * gilt hier der Code, und es steht am Testfall dabei: das Papier setzt das
  * Flag-Byte nur auf die Zeilen 1 bis 6, die App liest es auf 1 bis 7.
  *
- * Alle Fälle laufen gegen den Netzwerk-Bildschirm mit seinen acht Zeilen
- * (displayRows=8), also NSE0 bis NSE8.
+ * Alle Fälle laufen gegen den Netzwerk-Bildschirm, also NSE0 bis NSE8. Dessen
+ * displayRows=8 ist der höchste Zeilenindex, nicht die Anzahl - es sind neun
+ * Zeilen.
  */
 public final class NetDisplayTest {
 
@@ -62,8 +65,6 @@ public final class NetDisplayTest {
 	private final static int DIRECTORY = 2;
 	/** Bit4 - "CURSOR SELECT". */
 	private final static int CURSOR = 8;
-	/** Bit8 - Bild; im 3808-Papier "Don't Care". */
-	private final static int PICTURE = 128;
 	/** Keines der ausgewerteten Bits gesetzt. */
 	private final static int NONE = ' ';
 
@@ -72,11 +73,12 @@ public final class NetDisplayTest {
 		final NetDisplay.DisplayStatus s = read("0Internet Radio",
 				line(1, PLAYABLE, "Ein Titel"), line(2, DIRECTORY, "Ein Ordner"),
 				line(3, PLAYABLE | CURSOR, "Unter dem Cursor"),
-				line(4, PICTURE, "Mit Bild"), line(5, NONE, ""),
+				line(4, NONE, "Schlicht"), line(5, NONE, ""),
 				line(6, NONE, ""), line(7, NONE, ""), "8 [   4/  17]");
 
 		assertTrue(s.getDisplayLine(0).isPlayable());
 		assertFalse(s.getDisplayLine(0).isFolder());
+		assertFalse(s.getDisplayLine(0).isCursor());
 
 		assertTrue(s.getDisplayLine(1).isFolder());
 		assertFalse(s.getDisplayLine(1).isPlayable());
@@ -85,6 +87,8 @@ public final class NetDisplayTest {
 		assertTrue(s.getDisplayLine(2).isCursor());
 
 		assertFalse(s.getDisplayLine(3).isPlayable());
+		assertFalse(s.getDisplayLine(3).isFolder());
+		assertFalse(s.getDisplayLine(3).isCursor());
 	}
 
 	/**

--- a/app/src/test/java/de/pskiwi/avrremote/core/display/TunerDisplayTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/core/display/TunerDisplayTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.pskiwi.avrremote.core.display;
+
+import static org.junit.Assert.assertEquals;
+
+import java.text.DecimalFormatSymbols;
+
+import org.junit.Test;
+
+import de.pskiwi.avrremote.core.InData;
+
+/**
+ * Die Frequenzanzeige des analogen Tuners. Das Format steht im DENON AVR
+ * control protocol Ver. 5.2 (AVR-3808CI, Juli 2007):
+ *
+ * <pre>
+ * TF  AN****** (6 digits)  --- ****.** kHz at AM band   (&gt;050000 is AM.)
+ *                              ****.** MHz at FM band
+ * </pre>
+ *
+ * Sechs Ziffern, hundertstelgenau, und die Bandgrenze liegt bei 050000 - was
+ * darüber liegt ist AM, alles bis dahin FM.
+ *
+ * Nur die Umrechnung ist hier abgedeckt. Der Rest von TunerDisplay - Vorwahlen,
+ * HD-Radio, DAB, die Statuszeilen - hat weiterhin keine Tests.
+ */
+public final class TunerDisplayTest {
+
+	@Test
+	public void frequencyBelowTheBoundaryIsFM() {
+		assertEquals("FM : 104" + sep() + "30 MHz", frequency("10430"));
+	}
+
+	@Test
+	public void frequencyAboveTheBoundaryIsAM() {
+		assertEquals("AM : 1050" + sep() + "00 kHz", frequency("105000"));
+	}
+
+	/**
+	 * Der Grenzwert selbst gehört noch zu FM: das Papier schreibt
+	 * "&gt;050000 is AM", nicht "&gt;=". Ein echter Tuner steht nie dort - UKW
+	 * endet bei 10800, MW beginnt bei 52200 -, aber die Grenze soll da liegen,
+	 * wo sie beschrieben ist.
+	 */
+	@Test
+	public void theBoundaryItselfIsStillFM() {
+		assertEquals("FM : 500" + sep() + "00 MHz", frequency("050000"));
+	}
+
+	/** Ohne verwertbare Zahl bleibt die Anzeige leer statt falsch. */
+	@Test
+	public void unparsableFrequencyIsIgnored() {
+		assertEquals("", frequency("CMP"));
+	}
+
+	/**
+	 * Baut einen UKW-Tuner und schiebt ihm eine TF-Nutzlast unter.
+	 * ModelConfigurator und ISender werden dabei nicht angefasst, und der
+	 * Anzeige-Zuhörer steht auf dem Null-Objekt.
+	 */
+	private static String frequency(String payload) {
+		final TunerDisplay td = TunerDisplay.createFM(null, null);
+		final TunerDisplay.TunerFrequency f = td.new TunerFrequency();
+		f.update(new InData(payload));
+		return f.getFrequency();
+	}
+
+	/** String.format richtet sich nach der Standardsprache, der Test auch. */
+	private static char sep() {
+		return new DecimalFormatSymbols().getDecimalSeparator();
+	}
+}

--- a/app/src/test/java/de/pskiwi/avrremote/core/display/TunerDisplayTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/core/display/TunerDisplayTest.java
@@ -29,12 +29,13 @@ import de.pskiwi.avrremote.core.InData;
  * control protocol Ver. 5.2 (AVR-3808CI, Juli 2007):
  *
  * <pre>
- * TF  AN****** (6 digits)  --- ****.** kHz at AM band   (&gt;050000 is AM.)
- *                              ****.** MHz at FM band
+ * TF  AN****** (6 digits)  --- ****.** kHz at AM band  (&gt;050000 is AM.)
+ *                              ****.** MHz at FM band  (&lt;050000 is FM.)
  * </pre>
  *
- * Sechs Ziffern, hundertstelgenau, und die Bandgrenze liegt bei 050000 - was
- * darüber liegt ist AM, alles bis dahin FM.
+ * Sechs Ziffern, hundertstelgenau, Bandgrenze bei 050000. Beide Bedingungen
+ * sind strikt notiert, der Grenzwert selbst ist im Papier also gar nicht
+ * vergeben - siehe {@link #theBoundaryValueFallsToAM()}.
  *
  * Nur die Umrechnung ist hier abgedeckt. Der Rest von TunerDisplay - Vorwahlen,
  * HD-Radio, DAB, die Statuszeilen - hat weiterhin keine Tests.
@@ -52,20 +53,33 @@ public final class TunerDisplayTest {
 	}
 
 	/**
-	 * Der Grenzwert selbst gehört noch zu FM: das Papier schreibt
-	 * "&gt;050000 is AM", nicht "&gt;=". Ein echter Tuner steht nie dort - UKW
-	 * endet bei 10800, MW beginnt bei 52200 -, aber die Grenze soll da liegen,
-	 * wo sie beschrieben ist.
+	 * Der Grenzwert 050000 ist im Papier unbestimmt - beide Bedingungen sind
+	 * strikt, "&gt;050000 is AM" und "&lt;050000 is FM", er selbst gehört zu
+	 * keinem der beiden. Hier fällt er auf AM. Das ist eine Setzung, keine
+	 * Vorgabe: ein echter Tuner steht nie dort, UKW endet bei 10800 und MW
+	 * beginnt bei 52200. Der Fall steht hier, damit die Setzung nicht
+	 * unbemerkt hin und her wandert.
 	 */
 	@Test
-	public void theBoundaryItselfIsStillFM() {
-		assertEquals("FM : 500" + sep() + "00 MHz", frequency("050000"));
+	public void theBoundaryValueFallsToAM() {
+		assertEquals("AM : 500" + sep() + "00 kHz", frequency("050000"));
 	}
 
-	/** Ohne verwertbare Zahl bleibt die Anzeige leer statt falsch. */
+	/**
+	 * "CMP" quittiert das Ende eines Suchlaufs und ist keine Frequenz. Es darf
+	 * eine bereits angezeigte Frequenz nicht löschen - deshalb kommt hier erst
+	 * eine echte, dann CMP.
+	 */
 	@Test
-	public void unparsableFrequencyIsIgnored() {
-		assertEquals("", frequency("CMP"));
+	public void completionMessageLeavesTheFrequencyAlone() {
+		final TunerDisplay.TunerFrequency f = tuner();
+		f.update(new InData("10430"));
+		final String before = f.getFrequency();
+
+		f.update(new InData("CMP"));
+
+		assertEquals("FM : 104" + sep() + "30 MHz", before);
+		assertEquals(before, f.getFrequency());
 	}
 
 	/**
@@ -74,10 +88,13 @@ public final class TunerDisplayTest {
 	 * Anzeige-Zuhörer steht auf dem Null-Objekt.
 	 */
 	private static String frequency(String payload) {
-		final TunerDisplay td = TunerDisplay.createFM(null, null);
-		final TunerDisplay.TunerFrequency f = td.new TunerFrequency();
+		final TunerDisplay.TunerFrequency f = tuner();
 		f.update(new InData(payload));
 		return f.getFrequency();
+	}
+
+	private static TunerDisplay.TunerFrequency tuner() {
+		return TunerDisplay.createFM(null, null).new TunerFrequency();
 	}
 
 	/** String.format richtet sich nach der Standardsprache, der Test auch. */

--- a/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
@@ -17,30 +17,92 @@
 package de.pskiwi.avrremote.http;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
+import de.pskiwi.avrremote.http.AVRXMLInfo.Input;
+
 /**
- * Sichert das Trefferverhalten der beiden Series08-Parser ab, deren
- * OPTION_PATTERN von {@code matches()} mit umschließendem ".*" auf
- * {@code find()} umgestellt wurde (CodeQL java/polynomial-redos).
+ * Sichert das Trefferverhalten der drei Series08-Parser ab.
  *
- * Entscheidend ist die Auswahl bei mehreren Treffern in einer Zeile: das
- * frühere führende gierige ".*" nahm das rechteste Vorkommen, nicht das erste.
- * Genau das muss die Schleife weiterhin tun - sonst liest die App auf
- * 2008er-Geräten stillschweigend die falschen Namen aus. Beide Parser haben
- * dafür einen eigenen Fall, weil sie die Schleife getrennt implementieren.
+ * Ein Teil der Fälle stammt aus der Umstellung des OPTION_PATTERN von
+ * {@code matches()} mit umschließendem ".*" auf {@code find()} (CodeQL
+ * java/polynomial-redos). Entscheidend ist dort die Auswahl bei mehreren
+ * Treffern in einer Zeile: das frühere führende gierige ".*" nahm das rechteste
+ * Vorkommen, nicht das erste. Genau das muss die Schleife weiterhin tun - sonst
+ * liest die App auf 2008er-Geräten stillschweigend die falschen Namen aus.
+ * Series08ZoneRenameParser und Series08QuickSelectParser haben dafür einen
+ * eigenen Fall, weil sie die Schleife getrennt implementieren. Diese Fälle
+ * wurden aus dem Code abgeleitet, nicht aus einer echten Seite.
  *
- * Diese Klassen laufen nur gegen Receiver der 2008er-Serie, die zum Zeitpunkt
- * der Änderung nicht zum Testen zur Verfügung standen.
+ * Der andere Teil läuft gegen zwei Mitschnitte eines echten AVR-3808 unter
+ * src/test/resources (siehe {@link #capture(String)}). Sie decken
+ * Series08InputParser und Series08ZoneRenameParser ab und schreiben fest, was
+ * an einer selbst ausgedachten Zeichenkette nicht auffällt - vor allem, dass
+ * die Input-Seite noch zwei weitere &lt;select&gt; enthält, die nicht
+ * mitgelesen werden dürfen. Für Series08QuickSelectParser gibt es keinen
+ * Mitschnitt von d_option1.asp; der bleibt bei den synthetischen Fällen.
+ * Series08Reader ist gar nicht abgedeckt, der braucht HTTP.
  */
 public final class Series08ParserTest {
+
+	/**
+	 * Der Mitschnitt eines AVR-3808: fünf Quellen mit ihren Umbenennungen.
+	 *
+	 * Die Länge 5 ist dabei der eigentliche Punkt. Dieselbe Seite trägt noch
+	 * zwei weitere &lt;select&gt; - listInputMode (Auto, Ext.IN) und
+	 * listVideoSelect (SOURCE, HDP, TV/CBL, DVR). Beide stehen in eigenen
+	 * Zeilen, und nur deshalb liest der auf START_MARKER laufende Zeilenscan
+	 * sie nicht mit. Wer ihn auf das ganze Dokument ausweitet, holt sie
+	 * stillschweigend als Quellen herein.
+	 *
+	 * Nebenbei festgeschrieben: die Auffüll-Leerzeichen ("&gt;TUNER   &lt;")
+	 * fallen weg, Werte mit Schrägstrich überstehen das Muster, und das
+	 * " selected" am letzten &lt;option&gt; verschiebt den Anzeigenamen nicht.
+	 */
+	@Test
+	public void inputParserReadsCaptureInOrder() throws Exception {
+		final Series08InputParser p = new Series08InputParser(
+				capture("Series08Input.html"));
+
+		assertEquals("[TUNER->TUNER, HDP->Mediacen, TV/CBL->TV/CBL, "
+				+ "DVR->Wii, NET/USB->NET/USB]", format(p.get()));
+	}
+
+	/**
+	 * Ohne START_MARKER - eine 404 oder eine fremde Seite - bleibt die Liste
+	 * leer. Series08InputParser fängt die fehlende Zeile selbst ab, der
+	 * aufrufende Series08Reader prüft die Antwort nicht.
+	 */
+	@Test
+	public void inputParserWithoutMarkerReturnsEmpty() throws Exception {
+		final Series08InputParser p = new Series08InputParser(
+				stream("<html><body>404 Not Found</body></html>\n"));
+
+		assertTrue(p.get().isEmpty());
+	}
+
+	/**
+	 * get() ist einmalig: der Suchzeiger bleibt am Ende der Zeile stehen, ein
+	 * zweiter Aufruf liefert nichts mehr. Series08Reader ruft genau einmal auf.
+	 */
+	@Test
+	public void inputParserGetIsSingleShot() throws Exception {
+		final Series08InputParser p = new Series08InputParser(
+				capture("Series08Input.html"));
+
+		assertEquals(5, p.get().size());
+		assertTrue(p.get().isEmpty());
+	}
 
 	@Test
 	public void zoneRenameReadsNameAndValue() throws Exception {
@@ -80,6 +142,43 @@ public final class Series08ParserTest {
 		final List<String> names = p.getZoneNames();
 		assertEquals("Main", names.get(0));
 		assertEquals("Zone 2", names.get(1));
+	}
+
+	/**
+	 * Der Mitschnitt eines AVR-3808 - ein Gerät mit drei Zonen. Zone4 und Zone5
+	 * stehen gar nicht auf der Seite, dafür treten ihre Vorgabenamen ein; der
+	 * Fall darüber deckt nur eine Seite ganz ohne Treffer ab.
+	 *
+	 * Die echten Namen kommen auf 16 Zeichen aufgefüllt an
+	 * (value="ThisIsZone1     ") und werden getrimmt. Nicht angefasst werden
+	 * die einfach gequoteten name='radioLinkSetup' value='ON' und name='Color'
+	 * value='Gray' derselben Seite - das Muster verlangt value=".
+	 */
+	@Test
+	public void zoneRenameReadsCapture() throws Exception {
+		final Series08ZoneRenameParser p = new Series08ZoneRenameParser(
+				capture("Series08Zones.html"));
+		p.parse();
+
+		assertEquals("[ThisIsZone1, ThisIsZone2, ThisIsZone3, Zone 4, Zone 5]",
+				p.getZoneNames().toString());
+	}
+
+	/** getZoneName() nimmt 0..4, alles andere ist ein Programmierfehler. */
+	@Test
+	public void zoneRenameRejectsInvalidZone() throws Exception {
+		final Series08ZoneRenameParser p = new Series08ZoneRenameParser(
+				stream(""));
+		p.parse();
+
+		for (int zone : new int[] { -1, 5 }) {
+			try {
+				p.getZoneName(zone);
+				fail("Zone " + zone + " nicht abgewiesen");
+			} catch (IllegalArgumentException expected) {
+				// so soll es sein
+			}
+		}
 	}
 
 	@Test
@@ -137,5 +236,29 @@ public final class Series08ParserTest {
 
 	private static InputStream stream(String s) throws IOException {
 		return new ByteArrayInputStream(s.getBytes("UTF-8"));
+	}
+
+	/**
+	 * Mitschnitt aus src/test/resources, gleiches Package wie diese Klasse.
+	 * Über den Classpath und nicht von der Platte, anders als in
+	 * ModelConfiguratorTest: Gradle legt src/test/resources von sich aus dorthin
+	 * und meldet es als Task-Input, also braucht es weder einen Eintrag im
+	 * inputs.file-Block von build.gradle noch ein bestimmtes
+	 * Arbeitsverzeichnis.
+	 */
+	private static InputStream capture(String name) {
+		final InputStream in = Series08ParserTest.class
+				.getResourceAsStream(name);
+		assertNotNull("Mitschnitt fehlt: " + name, in);
+		return in;
+	}
+
+	/** Kurzform "name->rename", damit ein Fehlschlag die ganze Liste zeigt. */
+	private static String format(List<Input> inputs) {
+		final List<String> ret = new ArrayList<String>();
+		for (Input i : inputs) {
+			ret.add(i.getName() + "->" + i.getRename());
+		}
+		return ret.toString();
 	}
 }

--- a/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
+++ b/app/src/test/java/de/pskiwi/avrremote/http/Series08ParserTest.java
@@ -92,8 +92,9 @@ public final class Series08ParserTest {
 	}
 
 	/**
-	 * get() ist einmalig: der Suchzeiger bleibt am Ende der Zeile stehen, ein
-	 * zweiter Aufruf liefert nichts mehr. Series08Reader ruft genau einmal auf.
+	 * get() ist einmalig: der Suchzeiger bleibt hinter dem letzten Treffer
+	 * stehen, ein zweiter Aufruf liefert nichts mehr. Series08Reader ruft genau
+	 * einmal auf.
 	 */
 	@Test
 	public void inputParserGetIsSingleShot() throws Exception {

--- a/app/src/test/resources/de/pskiwi/avrremote/http/Series08Input.html
+++ b/app/src/test/resources/de/pskiwi/avrremote/http/Series08Input.html
@@ -1,0 +1,154 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML>
+<HEAD>
+<META http-equiv="Pragma" content="no-cache" />
+<META http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+<META http-equiv="Expires" content="-1" />
+<META http-equiv="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Source Select</TITLE>
+</HEAD>
+<script language="javaScript1.2">
+<!--
+	var val;
+	function refreshHref() {
+		location.href = this.location.href;
+	}
+	function listBox() {
+		inputsetupSubmit();
+	}
+	function radioBtn() {
+		inputsetupSubmit();
+	}
+	function buttonFuncRenameSet() {
+		document.inputsetup.setFuncRename.value = "on";
+		inputsetupSubmit();
+	}
+	function buttonClickSet(Kind) {
+		if(Kind=="Analog"){
+			document.inputsetup.setSourceLevelAnalog.value = "on";
+		}
+		if(Kind=="Digital"){
+			document.inputsetup.setSourceLevelDigital.value = "on";
+		}
+		inputsetupSubmit();
+	}
+	function buttonFuncRenameDefault() {
+		document.inputsetup.setFuncRenameDefault.value = "Default";
+		inputsetupSubmit();
+	}
+	function buttonClickDn(Kind) {
+		if(Kind=="Analog"){
+			if((isNaN(document.inputsetup.textSourceLevelAnalog.value)) ||
+			   (document.inputsetup.textSourceLevelAnalog.value =='')){
+				val = 0;
+			}else{
+				val = eval(document.inputsetup.textSourceLevelAnalog.value);
+			}
+			val = val - 1.0;
+			if(val < -12.0){
+				val = -12 ;
+			}
+			if(val > 12.0){
+				val = 12 ;
+			}
+			document.inputsetup.textSourceLevelAnalog.value = val;
+			document.inputsetup.setSourceLevelAnalog.value = "<";
+		}
+		if(Kind=="Digital"){
+			if((isNaN(document.inputsetup.textSourceLevelDigital.value)) ||
+			   (document.inputsetup.textSourceLevelDigital.value =='')){
+				val = 0;
+			}else{
+				val = eval(document.inputsetup.textSourceLevelDigital.value);
+			}
+			val = val - 1.0;
+			if(val < -12.0){
+				val = -12 ;
+			}
+			if(val > 12.0){
+				val = 12 ;
+			}
+			document.inputsetup.textSourceLevelDigital.value = val;
+			document.inputsetup.setSourceLevelDigital.value = "<";
+		}
+	}
+	function buttonClickUp(Kind) {
+		if(Kind=="Analog"){
+			if((isNaN(document.inputsetup.textSourceLevelAnalog.value)) ||
+			   (document.inputsetup.textSourceLevelAnalog.value =='')){
+				val = 0;
+			}else{
+				val = eval(document.inputsetup.textSourceLevelAnalog.value);
+			}
+			val = val + 1.0;
+			if(val < -12.0){
+				val = -12 ;
+			}
+			if(val > 12.0){
+				val = 12 ;
+			}
+			document.inputsetup.textSourceLevelAnalog.value = val;
+			document.inputsetup.setSourceLevelAnalog.value = ">";
+		}
+		if(Kind=="Digital"){
+			if((isNaN(document.inputsetup.textSourceLevelDigital.value)) ||
+			   (document.inputsetup.textSourceLevelDigital.value =='')){
+				val = 0;
+			}else{
+				val = eval(document.inputsetup.textSourceLevelDigital.value);
+			}
+			val = val + 1.0;
+			if(val < -12.0){
+				val = -12 ;
+			}
+			if(val > 12.0){
+				val = 12 ;
+			}
+			document.inputsetup.textSourceLevelDigital.value = val;
+			document.inputsetup.setSourceLevelDigital.value = ">";
+		}
+	}
+	function inputsetupSubmit() {
+		document.inputsetup.submit();
+	}
+// -->
+</script>
+
+<BODY text='#FFFFFF' bgcolor='#333333' link='#FFFFFF' vlink='#FFFFFF' alink='#FFFFFF'>
+<FORM name="inputsetup" action="s_inputsetup.asp" method="POST" target="inputsetup2">
+
+
+
+<TABLE cellspacing="0" cellpadding="0" border="0" >
+	<TR>
+      <TD><FONT size="4"><B>SOURCE SELECT</B></FONT></TD>
+		<TD align="right"><INPUT type="button" value="ReLoad" onClick="refreshHref()"></TD>
+	</TR>
+</TABLE>
+<HR size="5">
+
+<TABLE>
+	<TR> 
+		<TD><B>Source</B></TD>
+		<TD> <select size='1' name='listInputFunction' onchange='listBox()'STYLE='COLOR:#F5F5F5; background-color:#333333'><option value='TUNER'>TUNER   </option><option value='HDP'>Mediacen</option><option value='TV/CBL'>TV/CBL  </option><option value='DVR'>Wii     </option><option value='NET/USB' selected>NET/USB </option></select></TD>
+	</TR>
+</TABLE>
+<HR size="5">
+		<TABLE><TR><TD><B><a href='../../NETAUDIO/r_netaudio.asp' target='_top'>Play</a></B></TD></TR></TABLE><HR size='5'>
+		
+		
+		
+		
+		
+		<TABLE><TR><TD><B>Playback Mode</B></TD></TR><TR><TD><B>&nbsp;&nbsp;USB Select</B></TD><TD><INPUT type='radio' name='radioUsbSelect' value='FRO' onClick='radioBtn()' checked>Front<INPUT type='radio' name='radioUsbSelect' value='REA' onClick='radioBtn()'>Rear</TD></TR></TABLE>
+		<TABLE><TR><TD><B>&nbsp;&nbsp;Repeat</B></TD><TD><INPUT type='radio' name='radioUsbRepeat' value='ALL' onClick='radioBtn()'>All<INPUT type='radio' name='radioUsbRepeat' value='ONE' onClick='radioBtn()'>One<INPUT type='radio' name='radioUsbRepeat' value='OFF' onClick='radioBtn()' checked>Off</TD></TR></TABLE>
+		<TABLE><TR><TD><B>&nbsp;&nbsp;Random</B></TD><TD><INPUT type='radio' name='radioUsbRandom' value='ON' onClick='radioBtn()'>On<INPUT type='radio' name='radioUsbRandom' value='OFF' onClick='radioBtn()' checked>Off</TD></TR></TABLE>
+		<TABLE><TR><TD><B>&nbsp;&nbsp;Direct Play</B></TD><TD><INPUT type='radio' name='radioUsbDirectPlay' value='FAV' onClick='radioBtn()'>Favorite<INPUT type='radio' name='radioUsbDirectPlay' value='MUS' onClick='radioBtn()' checked>Music</TD></TR></TABLE><HR size='5'>
+		
+		
+		<TABLE><TR><TD><B>Input Mode</B></TD><TABLE><TR><TD><B>&nbsp;&nbsp;Input Mode</B></TD><TD><select size='1' name='listInputMode' onchange='listBox()'STYLE='COLOR:#F5F5F5; background-color:#333333'><option value='AUTO' selected>Auto</option><option value='EXT.IN-1'>Ext.IN</option></select></TD></TR></TABLE><HR size='5'>
+		<TABLE><TR><TD><B>Rename</B></TD><TD><INPUT type='text' name='textFuncRename' value="NET/USB" size='12' maxlength='8'>&nbsp;<INPUT type='button' name='setbtnFuncRename' value='Set' onClick='buttonFuncRenameSet()'><INPUT type='hidden' name='setFuncRename' value='off'>&nbsp;<INPUT type='button' name='setbtnFuncRenameDefault' value='Def' onClick='buttonFuncRenameDefault()'><INPUT type='hidden' name='setFuncRenameDefault' value='off'></TD></TR></TABLE><HR size='5'>
+		<TABLE><TR><TD><B>Other</B></TD></TR><TR><TD><B>&nbsp;&nbsp;Video Select</B></TD><TD><select size='1' name='listVideoSelect' onchange='listBox()'STYLE='COLOR:#F5F5F5; background-color:#333333'><option value='SOURCE' selected>SOURCE</option><option value='HDP'>Mediacen</option><option value='TV/CBL'>TV/CBL  </option><option value='DVR'>Wii     </option></select></TD></TR></TABLE><TABLE><TR><TD><B>&nbsp;&nbsp;Source Level</B></TD><TD><INPUT type='button' name='buttonInFuncLevDn' value='&lt;' onClick='buttonClickDn("Digital")'>&nbsp;<INPUT type='text' name='textSourceLevelDigital' size='4' maxlength='3' style='text-align:right;' value='0'>dB&nbsp;<INPUT type='button' name='buttonInFuncLevUp' value='&gt;' onClick='buttonClickUp("Digital")'>&nbsp;<INPUT type='button' name='setbtnInFuncLev' value='Set' onClick='buttonClickSet("Digital")'><INPUT type='hidden' name='setSourceLevelDigital' value='off'></TD></TR></TABLE><HR size='5'>
+</FORM>
+</BODY>
+</HTML>

--- a/app/src/test/resources/de/pskiwi/avrremote/http/Series08Zones.html
+++ b/app/src/test/resources/de/pskiwi/avrremote/http/Series08Zones.html
@@ -1,0 +1,98 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN">
+<HTML>
+<HEAD>
+<META http-equiv="Pragma" content="no-cache" />
+<META http-equiv="Cache-Control" content="no-cache, must-revalidate" />
+<META http-equiv="Expires" content="-1" />
+<META http-equiv="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>ZoneRename</TITLE>
+</HEAD>
+<script language="javaScript1.2">
+<!--
+	function Rename(){
+		document.ZoneRename.submit();
+	}
+	function radioBtn() {
+		document.ZoneRename.submit();
+	}
+	function reloadHref() { 
+	}
+
+
+// -->
+</script>
+<BODY text='#FFFFFF' bgcolor='#333333' link='#FFFFFF' vlink='#FFFFFF' alink='#FFFFFF' onLoad="reloadHref()">
+<FORM name="ZoneRename" action="s_zonerename.asp" method="POST" target="zonerename2">
+
+<B><FONT SIZE="5">Zone Rename</FONT></B>
+<CENTER>
+	<TABLE>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD colspan="2"><B><FONT SIZE="5">Main Zone</FONT></B></TD></TR>
+		<TR><TD colspan="2"><INPUT type='text' name='Main' value="ThisIsZone1     " size='24' MAXLENGTH='16'>
+</TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TR><TD colspan='2'><B><FONT SIZE='5'>Multi Zone2</FONT></B></TD></TR><TD colspan='2'><INPUT type='text' name='Zone2' value="ThisIsZone2     " size='24' MAXLENGTH='16'>
+</TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TR><TD colspan='2'><B><FONT SIZE='5'>Multi Zone3</FONT></B></TD></TR><TD colspan='2'><INPUT type='text' name='Zone3' value="ThisIsZone3     " size='24' MAXLENGTH='16'>
+</TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TR><TD><INPUT TYPE="button" value="Set Zone Name " onclick='Rename()'></TD></TR><TD></TD></TR>
+	</TABLE>
+<B><FONT SIZE="5">Top Menu Link Setup</FONT></B>
+	<TABLE>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD colspan="2"><B><INPUT type='radio' name='radioLinkSetup' value='ON' onClick='radioBtn()'>ON<INPUT type='radio' name='radioLinkSetup' value='OFF' onClick='radioBtn()' checked>OFF</B></TD></TR>
+	</TABLE>
+<B><FONT SIZE="5">Color Choice</FONT></B>
+	<TABLE>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD></TD><TD></TD></TR>
+		<TR><TD colspan="2"><B><INPUT type='radio' name='Color' value='Black' onClick='radioBtn()'>Black<INPUT type='radio' name='Color' value='Blue' onClick='radioBtn()'>Blue<INPUT type='radio' name='Color' value='Gray' onClick='radioBtn()' checked>Gray</B></TD></TR>
+	</TABLE>
+		<A href="../index.asp" target="_top"><B><FONT SIZE="5">Back Top Menu</FONT></B></A>
+</CENTER>
+	</BODY>
+</HTML>


### PR DESCRIPTION
Two commits, both closing gaps that were open because nothing could be checked against a real device or a written spec.

---

## 1. Series08 parsers against two captured AVR-3808 pages

`Series08ParserTest` said in its own javadoc that it was written blind: the cases came from the code, not from a device. `Series08InputParser` had no tests at all.

Two captured pages now live in `app/src/test/resources/de/pskiwi/avrremote/http/` and are parsed verbatim.

- **The input page carries two more `<select>`** besides `listInputFunction` — `listInputMode` (`Auto`, `Ext.IN`) and `listVideoSelect` (`SOURCE`, `HDP`, `TV/CBL`, `DVR`). Only the `START_MARKER` line scan keeps them out. Widening that scan pulls all six in silently.
- Values arrive **space-padded** (`>TUNER   <`, `value="ThisIsZone1     "`) and get trimmed.
- The zone page is from a **three-zone** receiver, so `Zone4`/`Zone5` fall back to defaults — the mixed case; the old test only covered a page with no matches at all.
- The **empty-page guard** in `Series08InputParser`, which `Series08Reader` relies on and never checks itself.
- `get()` on the input parser is **single-shot**.

Fixtures load through `getResourceAsStream`. Gradle puts `src/test/resources` on the test classpath and tracks it as a task input by itself, so this needs neither an `inputs.file` entry nor a particular working directory.

Drive-by: `Series08ZoneRenameParser.getZoneName` bounded with `zone > ZONE_KEYS.length`, so zone 5 threw `ArrayIndexOutOfBoundsException` instead of `IllegalArgumentException`.

## 2. NSE display reader against the 2007 protocol paper

`core/display/` had no tests at all. The DENON AVR control protocol Ver. 5.2 (AVR-3808CI, July 2007) writes the on-screen line format down, so the reader can be pinned against something other than itself:

```
NSA0**************_?????   Display Line1  - no flag byte
NSA1 ************_?????    Display Line3  - with flag byte
  _:Null
  ?:Exclusion(The character after Null should be disregarded)
  Bit1:Playable Music =1
  Bit4:CURSOR SELECT=1
```

`InDataTest` covers the framing — leading line digit, the null byte that ends the text with everything after it discarded, the UTF-8 decode. `NetDisplayTest` drives `NetDisplay.DisplayStatusReader` over a whole nine-line page: flag bits, cursor line, the asymmetric text offsets of first and last line, the page counter, the right trim, and that the reader refuses updates once fixed.

**On the paper's authority:** it documents `NSA`/`IPA`, the app speaks `NSE`/`IPE` — a later generation of the same commands. The framing is identical, the meaning of the individual line numbers is not: the paper puts the flag byte on lines 1..6, the app reads it on 1..7. Where they differ the code wins, and the test says so rather than pretending the paper covers it.

### One production change was needed

```java
private static boolean EXTENDED_DEBUG = EmulationDetector.isEmulator();
```

`EmulationDetector` reads `android.os.Build`, which is null on a bare JVM. That static initialiser threw `ExceptionInInitializerError` and shut every `InData`-using test out — for a debug string. The value is now read inside `toDebugString()`, where it is used; `EmulationDetector` still computes once, so this is a field read.

---

## Verification

`./gradlew test` green, **50 tests** in both variants, also with `--rerun-tasks`.

Each new test was checked by breaking the thing it pins — 20 mutations, reverted afterwards:

| Change to the production code | Test that goes red |
| --- | --- |
| `START_MARKER` scan widened to the whole document | `inputParserReadsCaptureInOrder` — list gains `AUTO->Auto, EXT.IN-1->Ext.IN, SOURCE->SOURCE, …` |
| `trim()` removed in either Series08 parser | `inputParserReadsCaptureInOrder` / `zoneRenameReadsCapture` |
| null guard removed at `Series08InputParser:40` | `inputParserWithoutMarkerReturnsEmpty` (NPE) |
| `>=` back to `>` | `zoneRenameRejectsInvalidZone` |
| playable bit `& 1` → `& 4` | `flagByteMarksPlayableDirectoryAndCursor` |
| cursor bit `& 8` → `& 4` | `cursorBitSetsTheCursorLine` |
| `cursorLine = line - 1` → `line` | `cursorBitSetsTheCursorLine` |
| line 0 text offset `1` → `2` | `firstAndLastLineCarryNoFlagByte` — `expected:<[I]nternet Radio> but was:<[]nternet Radio>` |
| right trim removed | `trailingPaddingIsTrimmed` |
| page counter `- 1` dropped | `lastLineCarriesThePageOffset` |
| page-info fallback `(0, 7)` → `(3, 7)` | `withoutPageInfoTheOffsetStaysAtZero` |
| `fixed` check removed | `readerRefusesUpdatesAfterCreateStatus` |
| null break removed in `extractLine` | `extractLineStopsAtTheNullByte`, `textEndsAtTheNullByte` |
| `UTF-8` → `ISO-8859-1` | `extractLineDecodesUtf8` |
| byte cast masked to 7 bits | `extractLineDecodesUtf8` |
| tuner band edge `<` forward to `<=` | `theBoundaryValueFallsToAM` |
| `CMP` branch wipes the frequency | `completionMessageLeavesTheFrequencyAlone` |
| directory bit `& 2` → `false` | `flagByteMarksPlayableDirectoryAndCursor` |
| frequency scaled by 10 instead of 100 | all three `TunerDisplayTest` frequency cases |

`inputParserGetIsSingleShot` has no such control — it only documents that the search offset stays put.

## 3. Two small fixes the display work turned up

`InData.extractLine` narrowed with `(byte) (data[i] > 127 ? data[i] - 256 : data[i])`. The ternary was a no-op — subtracting 256 leaves the low eight bits alone, which is exactly what the cast to `byte` keeps. Now a plain cast, with a comment so it does not grow back.

`TunerDisplay.convertFrequency` is **unchanged** at `freq < 50000`. A commit in this branch briefly moved it to `<=` on the grounds that the paper puts 050000 on the FM side; the review showed that is not what the paper says — line 715 reads `(<050000 is FM.)` directly under `(>050000 is AM.)`, so both bounds are strict and 050000 is undefined. Only the comment stays, recording that the tie is our choice. Nothing sits there in practice: FM ends at 10800, AM starts at 52200.

This adds `TunerDisplayTest`, the first coverage of `TunerDisplay` at all: the two bands, the undefined boundary value, and that a `CMP` search-complete message does not wipe a frequency already on screen. It reaches the inner `TunerFrequency` the same way `NetDisplayTest` reaches `DisplayStatusReader` — the pattern the remaining display classes can follow.

## Still open

`Series08QuickSelectParser` gets no real fixture — `d_option1.asp` was never captured. `Series08Reader` stays untested (needs HTTP). The rest of `TunerDisplay` (presets, HD Radio, DAB, status lines) and all of `BDDisplay` still have nothing, though both construct on a JVM, so the obstacle is only that nobody wrote the cases. `TODO.md` is narrowed to exactly that remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJYiak7auvjb2n6eZMJvzf



---

## 4. Review follow-up

A subagent review of the branch found **no production correctness bug** — it verified the byte narrowing is identical across all 65536 char values, the `EXTENDED_DEBUG` move is behaviour-neutral, and the `>=` fix is pinned. It did find six problems with the *reasoning*, all confirmed and now fixed:

- The tuner band edge went back to `<` (above).
- Two test cases were **proven vacuous by mutation** and are now real: `unparsableFrequencyIsIgnored` asserted `""` on a fresh `TunerFrequency` whose frequency is null anyway, and the `PICTURE` line asserted nothing about bit 8 — nor could it, since `LineState.isPicture()` has no caller anywhere in the tree and `DisplayLine` has no picture accessor. The case is dropped and the javadoc now says the bit is parsed and unread.
- `CLAUDE.md` stated the wrong mechanism for the stub `android.jar`: reading `Build.PRODUCT` does not throw, it returns null and the NPE comes from `toUpperCase()` on it; field initialisers are not generally safe either. Constructors are no-ops, field reads return null/0, **method calls throw**.
- `TODO.md` claimed `BDDisplay`'s inner classes can be instantiated from a test like `TunerDisplay`'s. They cannot — `BDDisplayStatus` is private static, `BDState` is private — so it needs the same widening as `ResilentConnector.ThreadHandler`. That is now what the item points at.
- Three smaller wording errors (line count off by one file revision, "eight lines" for a highest-index-of-nine, a search pointer described as stopping at end of line rather than after the last match).
