### PR TITLE
Release 1.6.1

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     android:installLocation="auto"
     android:label="AVR-Remote"
-    android:versionCode="125"
-    android:versionName="1.6.0" >
+    android:versionCode="126"
+    android:versionName="1.6.1" >
 
     <supports-screens
         android:anyDensity="true"

--- a/app/src/main/assets/whatsnew.html
+++ b/app/src/main/assets/whatsnew.html
@@ -8,6 +8,25 @@
 		</p>
 		</p>
 		</ul>
+		<b>1.6.1</b>
+		<ul>
+			<li>Fixed a crash that could close the whole app when Wi-Fi was
+				switched on or off (pskiwi)</li>
+			<li>Fixed: after a long standby the app came back disconnected and
+				stayed that way until it was closed and started again (pskiwi)</li>
+			<li>Fixed: returning to the app could freeze it for about a second
+				(pskiwi)</li>
+			<li>Fixed: on four-zone receivers the zone 4 controls stayed active
+				after the connection was lost (pskiwi)</li>
+			<li>Fixed: reading the input names from a 2008-series receiver could
+				fail if the receiver answered with an unexpected page (pskiwi)</li>
+			<li>The on-screen display follows the device orientation again instead
+				of being locked to portrait (pskiwi)</li>
+			<li>Logs sent by mail are considerably more useful: they carry the
+				error details, the thread and a sequence number to sort by. If you
+				have reported a problem before and it was not reproducible, a fresh
+				log is worth sending (pskiwi)</li>
+		</ul>
 		<b>1.6.0</b>
 		<ul>
 			<li><b>This version needs Android 7.0 or newer.</b> On older devices


### PR DESCRIPTION
versionCode 125 -> 126, versionName 1.6.0 -> 1.6.1. A patch number: no new features, no new receiver models, `minSdk` unchanged. What is in it is three connection bugs and their fallout.

Cut from `master` at a0a889a. **PR #34 is deliberately not in it** — it is still open and can go in after.

## Release notes, and where they come from

`whatsnew.html` carries seven entries, all credited `(pskiwi)`: every one of the 33 commits since `v1.6.0` is from this repository, so there is no pull request or issue to point at. The user-facing half of those commits:

| Entry | Commit |
| --- | --- |
| Crash on Wi-Fi on/off, taking the whole app | cb46f97, b8ea294 |
| Came back disconnected after a long standby | d15b6ae |
| Froze for about a second on returning to the app | 86cec6d |
| Zone 4 stayed active after the connection was lost | 2b73616 |
| Input names from a 2008-series receiver could fail | 2b73616 |
| OSD follows the device orientation again | 5143771 |
| Logs sent by mail are considerably more useful | bcfeb06, a2720c6, 555bb3f |

The Wi-Fi NPE is the reason not to sit on this: it was reported against 1.5.1, but the lines are unchanged since the initial commit, so **1.6.0 is exposed identically** — and `getNetworkInfo(TYPE_WIFI)` returning null out of a broadcast receiver takes the process, not just an activity.

The log rework gets an entry of its own although it is diagnostics rather than a feature, because it asks something of the user: a problem that was reported and could not be reproduced is worth reporting again now that exceptions, thread names and `#seq` are in the file.

Left out deliberately — none of it changes anything a user can see: the `CONNECTION.md` / `CLAUDE.md` work, the added tests, the deprecation inventory, and the debug-only build-info line.

## Not in the diff

`version.xml` is the Play Console wording and is untracked by design (`.gitignore`), so it is not here. It is written, at 489 and 491 characters against the 500-character limit.

`TODO.md` is unchanged: this release closes no item there.

## Verification

`./gradlew build` green, 25 tests, and the merged **release** manifest reads `versionCode 126` / `versionName 1.6.1` — checked in `merged_manifest/release/`, not just in the source file.

## After merging

`git tag v1.6.1 && git push origin master --tags` publishes a **public GitHub Release**; the Play Console upload is by hand, as always. Both are still to do — see [RELEASE.md](RELEASE.md), including the 512px store icon still outstanding from 1.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191jB7bNywh1M5djnzH5pp2