### PR TITLE
Stop naming D&M Holdings as the trademark owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Android remote control for Denon and Marantz receivers.
 
 
 This application is not affiliated with Denon or Marantz. 
-Denon and Marantz are registered trademarks of D&M Holdings, Inc. 
+Denon and Marantz are trademarks of their respective owners. 
 
 ![Check build](https://github.com/pskiwi/avr-remote/workflows/Check%20build/badge.svg)
 

--- a/app/src/main/assets/about.html
+++ b/app/src/main/assets/about.html
@@ -22,6 +22,6 @@ Thanks to everyone who contributed ideas, bug reports or tests to this project.
 This is experimental software. Try it on your own risk. <br />
 <br>
 This application is not affiliated with Denon or Marantz. <br />
-Denon and Marantz are registered trademarks of D&amp;M Holdings, Inc. </small>
+Denon and Marantz are trademarks of their respective owners. </small>
 </body>
 </html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 Use it at your own risk!
 
 This application is not affiliated with Denon or Marantz. 
-Denon and Marantz are registered trademarks of D&M Holdings, Inc. 
+Denon and Marantz are trademarks of their respective owners. 
 
 ## FAQ
 


### PR DESCRIPTION
The line **"Denon and Marantz are registered trademarks of D&M Holdings, Inc."** sits in three files, plus the Play Store listing where the question came up:

| File | Reaches users |
| --- | --- |
| `app/src/main/assets/about.html` | **ships in the app** — only with the next release |
| `README.md` | on merge |
| `docs/index.md` | on merge, GitHub Pages is live |

## Why

D&M Holdings has not been the owner for **nine years**, through three transactions:

- **March 2017** — Sound United buys the D+M Group
- **2022** — Masimo buys Sound United
- **23 September 2025** — Harman International, a Samsung subsidiary, [completes its purchase](https://www.whathifi.com/hi-fi/harman-now-owns-bowers-and-wilkins-marantz-and-denon-as-masimo-deal-completes)

## Why not just write the new owner

Two reasons, and the first is the interesting one.

**Who is recorded as registrant is a different question from who owns the group.** An assignment has to be recorded separately and usually lags — [secondary sources on the US register still show D&M Holdings for DENON](https://trademarks.justia.com/736/82/denon-73682015.html). DPMA and EUIPO were not checked at all, and the German store listing is precisely where a German register would be the one that counts. So the old line is not demonstrably *false*; it is stale and unverifiable, which is a different defect and not one that substituting another name would fix.

**And a name goes stale again.** This one has now outlived its accuracy through three owners without anybody touching it. Naming no entity is sufficient for a nominative-use disclaimer and cannot rot.

The word *registered* goes with it: registration status is per jurisdiction and was never verified for any of them.

## Not in this PR, on purpose

The model list in `docs/index.md`, two lines above the changed one, is stale in exactly the way the store listing was: it misses AVC-A1HDA, AVP-A1HDCI, AVR-100, AVR-3805, AVR-3806, SR-6005 and ASD-51, and writes `RCDN7`, `DNP720AE`, `MCR603`, `MER803`, `NA7004` without their dashes. Different claim, different subject, own change. The authoritative list is `@array/modelNames` in `res/values/lists.xml` — 60 entries including `AVR-Generic`, pinned by `ModelConfiguratorTest`.

`./gradlew assembleDebug` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191jB7bNywh1M5djnzH5pp2