### PR TITLE
Fill the GitHub release description from whatsnew.html

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -33,10 +33,23 @@ jobs:
         run: echo "$KEY_JKS" | base64 -d > key.jks; ./gradlew build; rm key.jks
       - name: Rename APK
         run: mv app/build/outputs/apk/release/app-release.apk avr-remote-${{ github.ref_name }}.apk
+      # Release notes come from the tagged version's block in whatsnew.html. If there is none --
+      # an rc tag, or notes not written yet -- the file stays empty and GitHub generates its own
+      # from the merged pull requests. Either way the release must still be created.
+      - name: Build release notes
+        id: notes
+        run: |
+          if python3 misc/release-notes.py "${{ github.ref_name }}" > release-notes.md; then
+            echo "generate=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "generate=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           name: Release ${{ github.ref_name }}
+          body_path: release-notes.md
+          generate_release_notes: ${{ steps.notes.outputs.generate }}
           draft: false
           prerelease: ${{ contains(github.ref,'rc') }}
           files: avr-remote-${{ github.ref_name }}.apk

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,22 @@ because none of it was recorded anywhere and most of it is not guessable from th
 
 `.github/workflows/releasebuild.yml` triggers on a tag matching `v*`. It builds with JDK 17, signs
 the release APK from the repository secrets, renames it to `avr-remote-<tag>.apk` and attaches it to
-a **GitHub Release**. A tag containing `rc` produces a pre-release.
+a **GitHub Release**, whose description it fills from the release notes (see below). A tag containing
+`rc` produces a pre-release.
+
+The description comes from `app/src/main/assets/whatsnew.html`, the same file the in-app dialog
+renders: `misc/release-notes.py` cuts out the block whose `<b>version</b>` heading matches the tag
+without its leading `v` and turns the `<li>` items into Markdown bullets. So the notes are written
+once, in step 2 below, and the release page cannot drift away from what the app shows. Before this
+was wired up the description stayed empty and had to be pasted in by hand after every release.
+
+**A missing block costs the description, never the release.** The script then prints nothing,
+exits 1, and the workflow falls back to GitHub's generated list of merged pull requests — which is a
+diff summary, not a user-facing one. That is the intended behaviour for an `rc` tag, and a warning
+sign for anything else: by the time the step runs the tag is pushed and the APK is built, so failing
+there would leave a tag with no release at all. The two things that trigger it are notes that were
+never written and a heading that does not match the tag exactly — `<b>v1.6.1</b>` or `<b>1.6.1a</b>`
+for tag `v1.6.1` do not match. Only whitespace inside the `<b>` is tolerated.
 
 **There is no Play Store automation.** No fastlane, no gradle-play-publisher, no service account —
 the Play upload has always been done by hand in the Play Console, and still has to be. The GitHub
@@ -46,12 +61,25 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
    last one.
 2. **Add release notes** in two places, which say the same thing at different lengths.
 
-   `app/src/main/assets/whatsnew.html` is the in-app dialog — a new `<b>version</b>` block at the top
-   of the list. `AboutActivity` renders the file, and `AVRRemote` opens it automatically on the first
-   start after an update, but only once a receiver is configured: the check at `AVRRemote.java:118`
-   is `getConnectionConfig().isDefined() && AVRSettings.isShowChangeLog(this)`. `isShowChangeLog()`
-   compares `packageInfo.versionCode` against the stored `AVRLastVersionCode` preference, so **an
-   unchanged `versionCode` means nobody ever sees the notes**.
+   `app/src/main/assets/whatsnew.html` is the in-app dialog **and the GitHub release description** —
+   a new `<b>version</b>` block at the top of the list, with the version written exactly as in the
+   tag but without the `v`. `AboutActivity` renders the file, and `AVRRemote` opens it automatically
+   on the first start after an update, but only once a receiver is configured: the check at
+   `AVRRemote.java:118` is `getConnectionConfig().isDefined() && AVRSettings.isShowChangeLog(this)`.
+   `isShowChangeLog()` compares `packageInfo.versionCode` against the stored `AVRLastVersionCode`
+   preference, so **an unchanged `versionCode` means nobody ever sees the notes**.
+
+   **English only.** The app ships two locales, but this file is not one of the localised resources —
+   there is a single `assets/whatsnew.html`, and German readers get the English text in the dialog
+   just as they do on the release page. Adding a German block would show it to everyone, twice. The
+   German wording belongs in `version.xml` below, where the Console splits it by language tag.
+
+   Check what the release page will show, before tagging rather than after — the fallback is silent,
+   and an empty-looking release is the first anyone hears of it:
+
+   ```sh
+   python3 misc/release-notes.py v1.6.1
+   ```
 
    `version.xml` is the Play Store wording, 500 characters per language. It is **not** checked in;
    `.gitignore` covers it, because it is input for the Console rather than part of the app. Its
@@ -96,10 +124,13 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
    git push origin master --tags
    ```
 
-5. **Watch the build**, then fetch the APK and verify the signature before handing it to anyone:
+5. **Watch the build**, then fetch the APK and verify the signature before handing it to anyone.
+   Read the release description in the same pass: a list of merged pull requests instead of the
+   notes means the block was not found and the fallback took over (see above).
 
    ```sh
    gh run watch
+   gh release view v1.6.0
    gh release download v1.6.0
    $ANDROID_HOME/build-tools/<version>/apksigner verify --print-certs avr-remote-v1.6.0.apk
    ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,21 @@ the release APK from the repository secrets, renames it to `avr-remote-<tag>.apk
 a **GitHub Release**, whose description it fills from the release notes (see below). A tag containing
 `rc` produces a pre-release.
 
-The description comes from `app/src/main/assets/whatsnew.html`, the same file the in-app dialog
-renders: `misc/release-notes.py` cuts out the block whose `<b>version</b>` heading matches the tag
-without its leading `v` and turns the `<li>` items into Markdown bullets. So the notes are written
-once, in step 2 below, and the release page cannot drift away from what the app shows. Before this
-was wired up the description stayed empty and had to be pasted in by hand after every release.
+The description is generated from `app/src/main/assets/whatsnew.html`, the same file the in-app
+dialog renders: `misc/release-notes.py` cuts out the block whose `<b>version</b>` heading matches the
+tag without its leading `v` and turns the `<li>` items into Markdown bullets. So the notes are
+written once, in step 2 below, and both places get them.
+
+**This is a deliberate trade, and it costs.** The workflow used to set no description at all, so the
+1.6.0 and 1.6.1 pages were written by hand afterwards — and written *longer* than the in-app dialog:
+around 3400 and 2400 characters, with an opening paragraph, a warning quote, `### Fixed` / `###
+Changed` headings and the reasoning behind each fix. The generated bullets for 1.6.1 are 863
+characters and flat. What was bought is that nobody has to remember the second step; what was given
+up is that depth. If a release deserves the long form, write it into the release page by hand after
+the workflow has run — but then it lives only there, which is the state this replaced.
+
+The conversion is lossy in one more way worth knowing: a link inside an entry keeps its text and
+loses its `href`, so entries have to read as prose rather than as "see here".
 
 **A missing block costs the description, never the release.** The script then prints nothing,
 exits 1, and the workflow falls back to GitHub's generated list of merged pull requests — which is a
@@ -74,13 +84,6 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
    just as they do on the release page. Adding a German block would show it to everyone, twice. The
    German wording belongs in `version.xml` below, where the Console splits it by language tag.
 
-   Check what the release page will show, before tagging rather than after — the fallback is silent,
-   and an empty-looking release is the first anyone hears of it:
-
-   ```sh
-   python3 misc/release-notes.py v1.6.1
-   ```
-
    `version.xml` is the Play Store wording, 500 characters per language. It is **not** checked in;
    `.gitignore` covers it, because it is input for the Console rather than part of the app. Its
    shape:
@@ -115,6 +118,12 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
      The 1.6.0 replacement of Apache HttpClient could only be tested against the hardware that was
      available; a user on an untested model needs to know that a missing input name is worth
      reporting.
+
+   Last, read back what the release page will show — before tagging, not after:
+
+   ```sh
+   python3 misc/release-notes.py v1.6.0
+   ```
 3. **Remove the items** in [TODO.md](TODO.md) that this release closes — that file records open work
    only, the history records what was done.
 4. **Commit, tag, push.** The tag convention is `v<versionName>`:
@@ -159,7 +168,7 @@ the alias CI actually signs with comes from the `KEY_ALIAS` secret and cannot be
       icon shipped in the APK is not used for the listing. Regenerate the PNG from
       `misc/play-store-icon.svg` if the artwork changes — the command is a comment at the top of that
       file, and the artwork has **four** copies in the tree that have to move together
-      (`res/drawable/ic_launcher_foreground.xml`, `app/src/main/assets/icon.svg`, `docs/avr-icon.svg`
+      (`app/src/main/res/drawable/ic_launcher_foreground.xml`, `app/src/main/assets/icon.svg`, `docs/avr-icon.svg`
       and the store SVG).
 
 ### Store listing
@@ -176,10 +185,10 @@ model list last. Keep that order.
 
 The model list there comes from `@array/modelNames` in `res/values/lists.xml`, not from the previous
 listing — that one had missed seven models and dropped the dashes from five. That makes **four**
-copies of the model list in the tree: `lists.xml`, `README.md`, `docs/index.md` and this file. Only
-the first is pinned by a test (`ModelConfiguratorTest`, against the classes in `models/`); the other
-three drift silently, and two of them had. Regenerate them from `lists.xml` rather than editing by
-hand:
+copies of the model list in the tree: `lists.xml`, `README.md`, `docs/index.md` and
+[store-listing.txt](store-listing.txt). Only the first is pinned by a test (`ModelConfiguratorTest`,
+against the classes in `models/`); the other three drift silently, and two of them had. Regenerate
+them from `lists.xml` rather than editing by hand:
 
 ```sh
 python3 -c "import re; s=open('app/src/main/res/values/lists.xml').read(); \

--- a/misc/release-notes.py
+++ b/misc/release-notes.py
@@ -21,21 +21,37 @@ import sys
 WHATSNEW = pathlib.Path(__file__).resolve().parent.parent / "app/src/main/assets/whatsnew.html"
 
 
+# Markdown means something by characters that are ordinary prose in the source. The receiver
+# families are written "AVR-*13" and "Marantz-SR*7", so an entry naming two of them would come
+# out italicised with the asterisks eaten.
+MARKDOWN_SPECIAL = re.compile(r"([\\`*_\[\]<])")
+
+
 def to_markdown(item):
-	# The bold in "<b>This version needs Android 7.0 or newer.</b>" is the point of that entry,
-	# so carry b/i over instead of dropping them with the rest of the tags. Unescape only after
-	# the tags are gone, or an escaped &lt;b&gt; would turn into one.
-	text = re.sub(r"</?(?:b|strong)>", "**", item)
-	text = re.sub(r"</?(?:i|em)>", "*", text)
-	text = re.sub(r"<[^>]+>", "", text)
-	return " ".join(html.unescape(text).split())
+	# Walk tags and text separately: the text has to be escaped, the markers this adds must not
+	# be. The bold in "<b>This version needs Android 7.0 or newer.</b>" is the point of that
+	# entry, so carry b/i over instead of dropping them with the rest of the tags -- links lose
+	# their href, which is why the entries have to read as prose rather than as "see here".
+	out = []
+	for part in re.split(r"(<[^>]+>)", item):
+		if not part.startswith("<"):
+			out.append(MARKDOWN_SPECIAL.sub(r"\\\1", html.unescape(part)))
+		elif re.fullmatch(r"</?(?:b|strong)>", part, re.I):
+			out.append("**")
+		elif re.fullmatch(r"</?(?:i|em)>", part, re.I):
+			out.append("*")
+	return " ".join("".join(out).split())
 
 
 def extract(source, version):
 	block = re.search(r"<b>\s*" + re.escape(version) + r"\s*</b>\s*<ul>(.*?)</ul>", source, re.S)
 	if block is None:
 		return None
-	return [to_markdown(i) for i in re.findall(r"<li>(.*?)</li>", block.group(1), re.S)]
+	# Hand-written HTML: one entry is spelled <lI>, another never closes its <li>. Splitting on
+	# the opening tag survives both, where a <li>(.*?)</li> pair drops the first silently and
+	# merges the second into its neighbour.
+	items = re.split(r"<li>", block.group(1), flags=re.I)[1:]
+	return [to_markdown(re.split(r"</li>", i, flags=re.I)[0]) for i in items]
 
 
 def main(argv):

--- a/misc/release-notes.py
+++ b/misc/release-notes.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Turn one version's block of whatsnew.html into Markdown for the GitHub release body.
+
+Usage: python3 misc/release-notes.py <tag>
+
+<tag> is the git tag, e.g. v1.6.1. The leading "v" is stripped and the rest has to match a
+<b>version</b> heading in app/src/main/assets/whatsnew.html exactly -- that file is written
+anyway (RELEASE.md, step 2), so the release page and the in-app dialog cannot drift apart.
+
+The notes go to stdout. No matching block -- an rc tag, or notes not written yet -- prints
+nothing and exits 1; the release workflow reads that as "fall back to GitHub's generated
+notes", not as a failure. Never let this abort a release: the tag is already pushed and the
+APK already built by the time it runs.
+"""
+
+import html
+import pathlib
+import re
+import sys
+
+WHATSNEW = pathlib.Path(__file__).resolve().parent.parent / "app/src/main/assets/whatsnew.html"
+
+
+def to_markdown(item):
+	# The bold in "<b>This version needs Android 7.0 or newer.</b>" is the point of that entry,
+	# so carry b/i over instead of dropping them with the rest of the tags. Unescape only after
+	# the tags are gone, or an escaped &lt;b&gt; would turn into one.
+	text = re.sub(r"</?(?:b|strong)>", "**", item)
+	text = re.sub(r"</?(?:i|em)>", "*", text)
+	text = re.sub(r"<[^>]+>", "", text)
+	return " ".join(html.unescape(text).split())
+
+
+def extract(source, version):
+	block = re.search(r"<b>\s*" + re.escape(version) + r"\s*</b>\s*<ul>(.*?)</ul>", source, re.S)
+	if block is None:
+		return None
+	return [to_markdown(i) for i in re.findall(r"<li>(.*?)</li>", block.group(1), re.S)]
+
+
+def main(argv):
+	if len(argv) != 2:
+		sys.exit(__doc__)
+	version = argv[1].removeprefix("v")
+	items = extract(WHATSNEW.read_text(encoding="utf-8"), version)
+	if not items:
+		print("no <b>%s</b> block in %s" % (version, WHATSNEW.name), file=sys.stderr)
+		return 1
+	print("\n".join("- " + i for i in items))
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main(sys.argv))


### PR DESCRIPTION
The release workflow set no `body`, so every release came out with an empty description and the notes had to be pasted into the release page by hand afterwards.

## What changes

`misc/release-notes.py` cuts the block whose `<b>version</b>` heading matches the tag (minus its leading `v`) out of `app/src/main/assets/whatsnew.html` and turns the `<li>` items into Markdown bullets — `<b>`/`<i>` survive as `**`/`*`, entities are unescaped. A new workflow step runs it into `release-notes.md`, which `softprops/action-gh-release` picks up via `body_path`.

That file is written for the in-app dialog anyway (RELEASE.md, step 2), so the release page cannot drift away from what the app shows. It is English only for the same reason the dialog is: there is no localised copy of it — the German wording lives in the untracked `version.xml` for the Play Console.

## The failure mode is deliberate

The step **must not** be able to abort a release: by the time it runs the tag is pushed and the APK is built, so a hard failure would leave a tag with no release at all. A missing block — an `rc` tag, or notes not written yet — writes an empty file and flips `generate_release_notes`, so GitHub falls back to its generated list of merged pull requests. That is silent, which is why RELEASE.md now asks for a local preview before tagging and a `gh release view` after.

## Verified

- `v1.6.1` and `v1.6.0` produce their full lists, including the bold first bullet of 1.6.0 and the `(#13/netmindz)` credits.
- `v1.7.0rc1` exits 1, leaving an empty `release-notes.md` and `generate=true`.
- The workflow YAML parses and the step order is Rename APK → Build release notes → Create Release.

Not verified: whether `action-gh-release@v3` overwrites the body when the same tag is re-run. RELEASE.md makes no claim either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLbdZQuFgD8g9euNQ5PTNh